### PR TITLE
Corriger l'apparence des différents états des champs de formulaire Fix/22

### DIFF
--- a/app/javascript/css/_common.scss
+++ b/app/javascript/css/_common.scss
@@ -5,6 +5,7 @@ $quaternary: #003285;
 $quinary: #2d3b66;
 $dark-gray: #585858;
 $light-gray: #c4c4c4;
+$disabled-gray: #fbfbfb;
 $text-muted: $light-gray;
 $success: #00d893;
 $cyan: #6cbeff;
@@ -182,15 +183,45 @@ aside.sidebar {
   }
 }
 
-.form-control, .custom-select, .custom-file-label {
-  border-color: white;
-  border-width: 2px;
+.form-control, .custom-select, .custom-file-label, .is-valid, .custom-select.is-valid, custom-file-input.is-valid, .form-control.is-valid,  {
+  outline: none !important;
+  border-color: white !important;
+  border-width: 1px;
+  border-top: solid 2px;
   @include box-shadow($bmd-shadow-2dp);
   &:focus {
-    border-color: $primary;
-    outline: 0;
+    outline: none !important;
+    border-bottom: solid 1px $primary !important;
     @include box-shadow($bmd-shadow-3dp);
   }
+}
+.custom-file-input.is-valid:focus ~ .custom-file-label{
+    outline: none !important;
+    border-bottom: solid 1px $primary !important;
+    @include box-shadow($bmd-shadow-3dp);
+}
+.input-search.is-focused {
+  outline: none !important;
+  border-bottom: solid 1px $primary !important;
+}
+
+.input-search.is-focused > input{
+  outline: none !important;
+}
+
+.was-validated .form-control:invalid, .form-control.is-invalid, .was-validated .custom-select:invalid, .custom-select.is-invalid, .was-validated .custom-file-input:invalid ~ .custom-file-label, .custom-file-input .is-invalid, .custom-file-input.is-invalid ~ .custom-file-label {
+  outline: none !important;
+  border-bottom: solid 1px $danger !important;
+  @include box-shadow($bmd-shadow-3dp);
+  &:focus {
+    outline: none !important;
+    border-bottom: solid 1px $danger !important;
+    @include box-shadow($bmd-shadow-3dp);
+  }
+}
+
+.form-control:disabled, .form-control[readonly] {
+    background-color: $disabled-gray;
 }
 
 .input-search {
@@ -213,13 +244,6 @@ aside.sidebar {
   }
 }
 
-.was-validated .custom-file-input:invalid ~ .custom-file-label, .custom-file-input.is-invalid ~ .custom-file-label {
-  border-width: 2px;
-}
-
-.custom-file-input.is-valid ~ .custom-file-label, .form-control.is-valid, .custom-select.is-valid {
-  border-color: white;
-}
 
 .custom-file-label {
   line-height: 1.25;

--- a/app/javascript/css/_common.scss
+++ b/app/javascript/css/_common.scss
@@ -183,22 +183,29 @@ aside.sidebar {
   }
 }
 
-.form-control, .custom-select, .custom-file-label, .is-valid, .custom-select.is-valid, custom-file-input.is-valid, .form-control.is-valid,  {
+.form-control, .custom-select, .custom-select.is-valid, .form-control.is-valid {
   outline: none !important;
-  border-color: white !important;
-  border-width: 1px;
-  border-top: solid 2px;
+  border: solid 2px white;
+  border-bottom: solid 1px white;
   @include box-shadow($bmd-shadow-2dp);
   &:focus {
     outline: none !important;
-    border-bottom: solid 1px $primary !important;
+    border: solid 2px white;
+    border-bottom: solid 1px $primary;
     @include box-shadow($bmd-shadow-3dp);
   }
 }
 
+.custom-file-input.is-valid ~ .custom-file-label{
+  outline: none !important;
+  border: solid 2px white;
+  border-bottom: solid 1px white;
+  @include box-shadow($bmd-shadow-2dp);
+}
 .custom-file-input.is-valid:focus ~ .custom-file-label{
     outline: none !important;
-    border-bottom: solid 1px $primary !important;
+    border: solid 2px white;
+    border-bottom: solid 1px $primary;
     @include box-shadow($bmd-shadow-3dp);
 }
 
@@ -211,21 +218,31 @@ aside.sidebar {
   outline: none !important;
 }
 
-.was-validated .form-control:invalid, .form-control.is-invalid, .was-validated .custom-select:invalid, .custom-select.is-invalid, .custom-file-input .is-invalid, .custom-file-input.is-invalid ~ .custom-file-label {
+.form-control.is-invalid, .custom-select.is-invalid {
   outline: none !important;
-  border-bottom: solid 1px $danger !important;
-  @include box-shadow($bmd-shadow-3dp);
+  border: solid 2px white;
+  border-bottom: solid 1px $danger;
+  @include box-shadow($bmd-shadow-2dp);
   &:focus {
     outline: none !important;
-    border-bottom: solid 1px $danger !important;
+    border: solid 2px white;
+    border-bottom: solid 1px $danger;
     @include box-shadow($bmd-shadow-3dp);
   }
 }
 
-.custom-file-input.invalid:focus ~ .custom-file-label{
-    outline: none !important;
-    border-bottom: solid 1px $danger !important;
-    @include box-shadow($bmd-shadow-3dp);
+.custom-file-input.is-invalid ~ .custom-file-label{
+  outline: none !important;
+  border: solid 2px white;
+  border-bottom: solid 1px $danger;
+  @include box-shadow($bmd-shadow-2dp);
+}
+
+.custom-file-input.is-invalid:focus ~ .custom-file-label{
+  outline: none !important;
+  border: solid 2px white;
+  border-bottom: solid 1px $danger;
+  @include box-shadow($bmd-shadow-3dp);
 }
 
 .form-control:disabled, .form-control[readonly] {

--- a/app/javascript/css/_common.scss
+++ b/app/javascript/css/_common.scss
@@ -195,11 +195,13 @@ aside.sidebar {
     @include box-shadow($bmd-shadow-3dp);
   }
 }
+
 .custom-file-input.is-valid:focus ~ .custom-file-label{
     outline: none !important;
     border-bottom: solid 1px $primary !important;
     @include box-shadow($bmd-shadow-3dp);
 }
+
 .input-search.is-focused {
   outline: none !important;
   border-bottom: solid 1px $primary !important;
@@ -209,7 +211,7 @@ aside.sidebar {
   outline: none !important;
 }
 
-.was-validated .form-control:invalid, .form-control.is-invalid, .was-validated .custom-select:invalid, .custom-select.is-invalid, .was-validated .custom-file-input:invalid ~ .custom-file-label, .custom-file-input .is-invalid, .custom-file-input.is-invalid ~ .custom-file-label {
+.was-validated .form-control:invalid, .form-control.is-invalid, .was-validated .custom-select:invalid, .custom-select.is-invalid, .custom-file-input .is-invalid, .custom-file-input.is-invalid ~ .custom-file-label {
   outline: none !important;
   border-bottom: solid 1px $danger !important;
   @include box-shadow($bmd-shadow-3dp);
@@ -218,6 +220,12 @@ aside.sidebar {
     border-bottom: solid 1px $danger !important;
     @include box-shadow($bmd-shadow-3dp);
   }
+}
+
+.custom-file-input.invalid:focus ~ .custom-file-label{
+    outline: none !important;
+    border-bottom: solid 1px $danger !important;
+    @include box-shadow($bmd-shadow-3dp);
 }
 
 .form-control:disabled, .form-control[readonly] {

--- a/app/javascript/css/_devise.scss
+++ b/app/javascript/css/_devise.scss
@@ -27,10 +27,10 @@
     }
   }
   .form-control {
-    border: 2px solid $card-border-color;
+    border: 2px solid $card-border-color !important;
     box-shadow: none;
     &:focus {
-      border: 2px solid $card-border-color;
+      border: 2px solid $card-border-color !important;
       box-shadow: none;
     }
   }

--- a/app/javascript/css/_devise.scss
+++ b/app/javascript/css/_devise.scss
@@ -27,10 +27,10 @@
     }
   }
   .form-control {
-    border: 2px solid $card-border-color !important;
+    border: 2px solid $card-border-color;
     box-shadow: none;
     &:focus {
-      border: 2px solid $card-border-color !important;
+      border: 2px solid $card-border-color;
       box-shadow: none;
     }
   }


### PR DESCRIPTION
Correction sur tous les champs texte, listes déroulante, rechercher, import-File.

J'ai laissé la même apparence pour les champs de connections (admin) et textearea.
- champs connexion ne change pas, et dans n'importe quel cas.
- Textarea sont encadre en bleu claire.

