### PR TITLE
Impossible de créer une annonce directement au statut publié Fix/34

### DIFF
--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -47,10 +47,9 @@ class Admin::JobOffersController < Admin::BaseController
   def create_and_publish
     @job_offer = JobOffer.new(job_offer_params)
     @job_offer.owner = current_administrator
-
+    @job_offer.publish
     respond_to do |format|
       if @job_offer.save 
-        @job_offer.publish!
         format.html { redirect_to [:admin, :job_offers], notice: t('.success') }
         format.json { render :show, status: :created, location: @job_offer }
       else

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -44,6 +44,23 @@ class Admin::JobOffersController < Admin::BaseController
   def edit
   end
 
+  def create_and_publish
+    @job_offer = JobOffer.new(job_offer_params)
+    @job_offer.owner = current_administrator
+
+    respond_to do |format|
+      if @job_offer.save 
+        @job_offer.publish!
+        format.html { redirect_to [:admin, :job_offers], notice: t('.success') }
+        format.json { render :show, status: :created, location: @job_offer }
+        
+      else
+        format.html { render :new }
+        format.json { render json: @job_offer.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
   # POST /admin/job_offers
   # POST /admin/job_offers.json
   def create

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -53,7 +53,6 @@ class Admin::JobOffersController < Admin::BaseController
         @job_offer.publish!
         format.html { redirect_to [:admin, :job_offers], notice: t('.success') }
         format.json { render :show, status: :created, location: @job_offer }
-        
       else
         format.html { render :new }
         format.json { render json: @job_offer.errors, status: :unprocessable_entity }


### PR DESCRIPTION
Ajout de la route. + fonctionnalité dans le controler


Au départ je voulait faire ça : 
`if @job_offer.save && @job_offer.publish` à la ligne 52
j'ai aussi voulu faire avant le save:
`@job_offer.state = @job_offer.state.published` à la ligne 50

      
Mais ça ne fonctionne pas (l'offre rester en brouillon) alors j'ai estimé que lors de l'ajout d'une offre il est forcément "draf" et je la modifie en published pendant la validation.

