### PR TITLE
feat: enable FranceConnect on apply page

### DIFF
--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -32,6 +32,12 @@ class JobOffersController < ApplicationController
 
   # GET /job_offers/1/apply
   # GET /job_offers/1/apply.json
+  def old_apply
+    redirect_to apply_job_offers_path(id: params[:id]), status: :moved_permanently
+  end
+
+  # GET /job_offers/apply?id=1
+  # GET /job_offers/apply.json?id=1
   def apply
     # Store location if user signup after
     store_location_for(:user, request.fullpath)
@@ -107,11 +113,15 @@ class JobOffersController < ApplicationController
   end
 
   def set_job_offer
+    if params[:id].blank?
+      return redirect_to job_offers_url
+    end
+
     @job_offer = JobOffer.find(params[:id])
     if !@job_offer.published? && !always_display_job_offer(@job_offer)
       raise JobOfferNotAvailableAnymore.new(job_offer_title: @job_offer.title)
     end
-    return redirect_to @job_offer, status: :moved_permanently if params[:id] != @job_offer.slug
+    redirect_to @job_offer, status: :moved_permanently if params[:id] != @job_offer.slug
   end
 
   def job_application_params

--- a/app/views/devise/shared/_france_connect.html.haml
+++ b/app/views/devise/shared/_france_connect.html.haml
@@ -9,7 +9,7 @@
 - if devise_mapping.omniauthable? && resource_class.omniauth_providers.include?(provider)
   .text-center
     %p FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne
-    = button_to user_france_connect_omniauth_authorize_path, class: "france-connect-link" do
+    = button_to user_france_connect_omniauth_authorize_path, class: "france-connect-link", "data-turbo": false do
       .normal= image_pack_tag('images/franceconnect-bouton.svg')
       .hover= image_pack_tag('images/franceconnect-bouton-hover.svg')
     .france-connect-details.rf-mt-2w= link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank"

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -1,6 +1,5 @@
--# Hide button until solution for CORS error is found
--# - unless user_signed_in?
--#   = render "devise/shared/france_connect"
+- unless user_signed_in?
+  = render "devise/shared/france_connect"
 = simple_form_for(@job_application, url: [:send_application, @job_offer], method: :post, data: { turbo: true }) do |f|
   .form-inputs.mt-3
     = f.error_notification

--- a/app/views/job_offers/_job_offer_content.html.haml
+++ b/app/views/job_offers/_job_offer_content.html.haml
@@ -6,4 +6,4 @@
     = sanitize(job_offer.send(field))
 - if display_apply_button && !(controller.action_name == 'apply')
   .rf-grid-row.rf-grid-row--center.rf-mt-4w
-    = link_to t('.apply'), [:apply, @job_offer], class: 'rf-btn rf-btn--lg', rel: 'noindex nofollow'
+    = link_to t('.apply'), apply_job_offers_path(id: @job_offer.slug), class: 'rf-btn rf-btn--lg', rel: 'noindex nofollow'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,8 +177,11 @@ Rails.application.routes.draw do
   end
 
   resources :job_offers, path: "offresdemploi", only: %i[index show] do
-    member do
+    collection do
       get :apply
+    end
+    member do
+      get :apply, to: "job_offers#old_apply"
       post :send_application
       get :successful
     end

--- a/spec/requests/job_offers_spec.rb
+++ b/spec/requests/job_offers_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe "JobOffers", type: :request do
     end
   end
 
-  describe "GET /job_offers/:id/apply" do
+  describe "GET /job_offers/apply?id=:id" do
     it "returns 200 when fetching a specific job offers application page" do
       job_offer = create(:job_offer)
       job_offer.publish!
-      get apply_job_offer_path(job_offer)
+      get apply_job_offers_path(id: job_offer.slug)
       expect(response).to have_http_status(200)
     end
   end


### PR DESCRIPTION
fix #431

FranceConnect (in production only) need a fix url to enable CORS request so I move from /job_offers/:id/apply to /job_offers/apply?id=:id