### PR TITLE
feat: remove preferred user from list

### DIFF
--- a/app/controllers/admin/preferred_users_controller.rb
+++ b/app/controllers/admin/preferred_users_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Admin::PreferredUsersController < Admin::InheritedResourcesController
+  def destroy
+    if @preferred_user.destroy
+      redirect_back(fallback_location: [:admin, @preferred_user.preferred_users_list], notice: t(".success"))
+    else
+      redirect_back(fallback_location: [:admin, @preferred_user.preferred_users_list], notice: t(".error"))
+    end
+  end
+end

--- a/app/views/admin/preferred_users_lists/_user.html.haml
+++ b/app/views/admin/preferred_users_lists/_user.html.haml
@@ -1,0 +1,2 @@
+- preferred_user = @preferred_users_list.preferred_users.find_by(user: user)
+= render partial: '/admin/users/user', locals: {user: user, preferred_user: preferred_user}

--- a/app/views/admin/preferred_users_lists/show.html.haml
+++ b/app/views/admin/preferred_users_lists/show.html.haml
@@ -47,7 +47,7 @@
                   Candidatures
                 .col-12.personal-profile-address-short
                   Secteur
-          = render partial: '/admin/users/user', collection: @preferred_users_filtered
+          = render partial: 'user', collection: @preferred_users_filtered
           .mt-5
             = will_paginate @preferred_users_filtered, params: { controller: 'users', action: controller.action_name }
         - else

--- a/app/views/admin/users/_user.html.haml
+++ b/app/views/admin/users/_user.html.haml
@@ -1,4 +1,5 @@
 - last_job_application = user.last_job_application
+- preferred_user ||= false
 .row
   - if defined?(list)
     .col-auto.align-self-center.text-center
@@ -34,5 +35,10 @@
           %ul.list-inline.mb-0.actions.mt-2.mt-md-0
             %li.list-inline-item
               = link_to listing_admin_user_path(user), role: :button do
-                = fa_icon 'star'
+                = fa_icon 'menu'
                 = t('.my_preferred_user_lists')
+            - if preferred_user
+              %li.list-inline-item
+                = link_to [:admin, preferred_user], role: :button, method: :delete, data: {confirm: t('buttons.confirm')} do
+                  = fa_icon 'delete'
+                  = t('.remove_user')

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -358,7 +358,6 @@ fr:
         card_1_title_new: "1. Rédaction de l'offre"
         card_1_title_edit: "1. Édition de l'offre %{job_offer_identifier}"
         card_1_1_title: "1.1 Description de l'offre"
-        card_1_1_title: "1.1 Description de l'offre"
         card_1_2_title: "1.2 Paramètres de l'offre"
         card_1_3_title: "1.3. Estimation rémunération salariale"
         estimate_monthly_salary_net_html: "Fourchette de référence : <span class='estimate_monthly_salary_net_reference'>%{value}</span>"
@@ -490,8 +489,8 @@ fr:
       unsuspend:
         success: "Utilisateur réactivé"
       user:
-        my_preferred_user_lists: "Mon vivier"
-        remove_user: "Supprimer de cette liste"
+        my_preferred_user_lists: "Listes"
+        remove_user: "Retirer"
         subscribed_on: "Inscrit le %{date}"
       head:
         nav_emails: "Courriels"
@@ -946,6 +945,9 @@ fr:
     preferred_users:
       form:
         title: "Note personnelle"
+      destroy:
+        success: "Candidat·e retiré·e avec succès"
+        error: "Une erreur s'est produite"
     preferred_users_lists:
       send_job_offer:
         success: "Offre envoyée aux candidats"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
         end
       end
     end
-    resources :preferred_users
+    resources :preferred_users, only: :destroy
     resources :preferred_users_lists, path: "liste-candidats" do
       member do
         get :export

--- a/spec/factories/preferred_users.rb
+++ b/spec/factories/preferred_users.rb
@@ -2,9 +2,8 @@
 
 FactoryBot.define do
   factory :preferred_user do
-    administrator { nil }
-    user { nil }
-    preferred_users_list { nil }
+    user
+    preferred_users_list
   end
 end
 

--- a/spec/requests/admin/preferred_users_spec.rb
+++ b/spec/requests/admin/preferred_users_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::PreferredUsers", type: :request do
+  let(:preferred_user) { create(:preferred_user) }
+  let(:user) { preferred_user.user }
+  let(:preferred_users_list) { preferred_user.preferred_users_list }
+
+  before { sign_in preferred_users_list.administrator }
+
+  describe "GET /destroy" do
+    it "removes user from the list and redirects to the list" do
+      delete admin_preferred_user_path(preferred_user)
+      expect(response).to redirect_to(admin_preferred_users_list_path(preferred_users_list))
+      expect(preferred_users_list.users).not_to include(user)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1127

On améliore un peu la card qui représente une candidature dans une liste, afin de : 

1. rendre plus explicite l'action qui mène à l'écran des listes dans laquelle cette candidature est incluse, en renommant "Mon vivier" en "Listes"
2. retirer directement une candidature de la liste courante

![image](https://user-images.githubusercontent.com/1193334/174047511-f36be0d5-20a1-4f86-ac50-124144e2520c.png)
