### PR TITLE
recompute notifications count when deleting user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::UsersController < Admin::InheritedResourcesController
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_index
+
   def index
     pq = params[:q] || {}
     pq[:concerned] = current_administrator if pq[:concerned]
@@ -105,11 +107,10 @@ class Admin::UsersController < Admin::InheritedResourcesController
 
   def destroy
     if @user.destroy
-      redirect_to(admin_users_path, notice: t(".success"))
+      redirect_back(fallback_location: %i[admin users], notice: t(".success"))
     else
       reason = @user.errors.full_messages.join(", ")
-      msg = t(".failure", reason: reason)
-      redirect_back(fallback_location: %i[admin users], notice: msg)
+      redirect_back(fallback_location: %i[admin users], notice: t(".failure", reason: reason))
     end
   end
 
@@ -137,4 +138,10 @@ class Admin::UsersController < Admin::InheritedResourcesController
   end
 
   alias_method :resource_params, :permitted_params
+
+  private
+
+  def redirect_to_index
+    redirect_to admin_users_path
+  end
 end

--- a/app/models/concerns/deletion_flow.rb
+++ b/app/models/concerns/deletion_flow.rb
@@ -58,6 +58,7 @@ module DeletionFlow
       job_application.emails.destroy_all
       job_application.messages.destroy_all
       job_application.job_application_files.destroy_all
+      job_application.compute_notifications_counter!
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,7 @@ class User < ApplicationRecord
 
   attr_accessor :is_deleted, :delete_photo
 
+  before_destroy :mark_job_applications_as_read
   before_update :destroy_photo
   before_save :remove_mark_for_deletion
 
@@ -127,6 +128,10 @@ class User < ApplicationRecord
 
   def remove_mark_for_deletion
     self.marked_for_deletion_on = nil
+  end
+
+  def mark_job_applications_as_read
+    job_applications.map(&:mark_as_read!)
   end
 end
 


### PR DESCRIPTION
see #1279

Lorsqu'on supprime un·e user, ses emails et documents sont également supprimés. On en profite pour recalculer le nombre de notifications pour l'administrateur·rice, afin d'avoir un compte à jour.