### PR TITLE
feat: multi recipients email

### DIFF
--- a/app/controllers/admin/multiple_recipients_emails_controller.rb
+++ b/app/controllers/admin/multiple_recipients_emails_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Admin::MultipleRecipientsEmailsController < Admin::BaseController
+  load_and_authorize_resource :job_offer
+
+  helper_method :is_form_disabled?
+
+  def new
+    @job_applications = @job_offer.job_applications.with_user.send(state)
+  end
+
+  def create
+    if @multiple_recipients_email.save
+      redirect_to [:board, :admin, @job_offer], notice: t(".success")
+    else
+      @job_applications = @job_offer.job_applications.where(id: @multiple_recipients_email.job_application_ids)
+      render :new
+    end
+  end
+
+  private
+
+  def multiple_recipients_email_params
+    params
+      .require(:multiple_recipients_email)
+      .permit(:subject, :body, job_application_ids: [], attachments: [])
+      .merge(sender: current_administrator)
+      .to_h
+      .symbolize_keys
+  end
+
+  def state
+    state_param = params[:state]
+    if JobApplication.states.key?(state_param)
+      state_param
+    else
+      JobApplication.states.keys.first
+    end
+  end
+
+  def is_form_disabled?
+    @job_offer.archived?
+  end
+end

--- a/app/javascript/css/admin.scss
+++ b/app/javascript/css/admin.scss
@@ -133,7 +133,8 @@ $job-application-gutter: 3px;
   height: 110px;
 }
 
-#email_body {
+#email_body,
+#multiple_recipients_email_body {
   height: 200px;
 }
 

--- a/app/javascript/js/email-template-select-handling.js
+++ b/app/javascript/js/email-template-select-handling.js
@@ -5,11 +5,11 @@ export default function emailTemplateSelectHandling() {
       let detail = event.detail
       let emailTemplate = detail[0]
       if (emailTemplate) {
-        let subjectNode = document.getElementById('email_subject')
+        let subjectNode = document.querySelector('[id$="email_subject"]')
         if (subjectNode !== null) {
           subjectNode.value = emailTemplate.subject
         }
-        let bodyNode = document.getElementById('email_body')
+        let bodyNode = document.querySelector('[id$="email_body"]')
         if (bodyNode !== null) {
           bodyNode.value = emailTemplate.body
         }

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -126,6 +126,7 @@ class JobApplication < ApplicationRecord
   scope :finished, -> { where(state: FINISHED_STATES) }
   scope :not_finished, -> { where.not(state: FINISHED_STATES) }
   scope :between, ->(a, b) { where(created_at: b..a) }
+  scope :with_user, -> { where.not(user: nil) }
 
   def set_employer
     self.employer_id ||= job_offer.employer_id

--- a/app/models/multiple_recipients_email.rb
+++ b/app/models/multiple_recipients_email.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class MultipleRecipientsEmail
+  include ActiveModel::Model
+
+  attr_accessor :subject, :body, :job_application_ids, :attachments, :sender
+
+  validates :subject, :body, :sender, :job_application_ids, presence: true
+
+  def initialize(subject: nil, body: nil, job_application_ids: nil, sender: nil, attachments: nil)
+    @subject = subject
+    @body = body
+    @job_application_ids = job_application_ids
+    @sender = sender
+    @attachments = attachments
+  end
+
+  def save(params = {})
+    return false unless valid?
+
+    Email.transaction do
+      emails.map(&:save!)
+      emails.each { |email| ApplicantNotificationsMailer.new_email(email.id).deliver_later(wait: 5.seconds) }
+    end
+  end
+
+  private
+
+  def emails
+    @emails ||= job_application_ids.map { |job_application_id|
+      Email.new(
+        subject: @subject,
+        body: @body,
+        job_application: JobApplication.find(job_application_id),
+        sender: @sender,
+        attachments: @attachments
+      )
+    }
+  end
+end

--- a/app/views/admin/job_offers/_board_column.html.haml
+++ b/app/views/admin/job_offers/_board_column.html.haml
@@ -1,7 +1,10 @@
 .list{id: "job-application--state-#{state_name}", data: {state: state_name}}
   %header
-    = JobApplication.human_attribute_name("state/#{state_name}")
-    = surround '(', ')' do
-      %span.total= job_applications.size
+    .d-flex.flex-row.justify-content-between 
+      %div 
+        = JobApplication.human_attribute_name("state/#{state_name}")
+        = surround '(', ')' do
+          %span.total= job_applications.size
+      = link_to fa_icon('email'), [:new, :admin, @job_offer, :multiple_recipients_email, state: state_name], title: t('buttons.email')
   .d-flex.flex-column.cards{data: {state: state_name}}
     = render partial: 'job_application', collection: job_applications, locals: {with_header: false}

--- a/app/views/admin/multiple_recipients_emails/new.html.haml
+++ b/app/views/admin/multiple_recipients_emails/new.html.haml
@@ -1,0 +1,32 @@
+.container-fluid.pt-3
+  .row 
+    .col-12.col-md-10.mx-md-auto
+      .card
+        .card-header.bg-white.font-weight-bold.text-secondary
+          = fa_icon('file-document', class: 'text-secondary')
+          = t('.title')
+        .card-subheader.bg-card-bg.font-weight-bold.text-muted
+          %ul.list-inline
+            - for job_application in @job_applications
+              %li.list-inline-item
+                = job_application.user.full_name
+        .card-body.bg-white
+          = simple_form_for(:email, url: [:admin, :email_templates], method: :get, remote: true, html: {id: :email_template_selector, class: 'auto-submit'}, defaults: { disabled: is_form_disabled? }) do |f|
+            .form-inputs
+              = f.input :template, collection: EmailTemplate.all
+
+          = simple_form_for([:admin, @job_offer, @multiple_recipients_email], defaults: { disabled: is_form_disabled? }) do |f|
+            = f.error_notification 
+            = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
+
+            .form-inputs
+              - for job_application in @job_applications
+                = f.hidden_field :job_application_ids, value: job_application.id, multiple: true
+              = f.input :subject
+              = f.input :body, as: :text
+              = f.file_field :attachments, multiple: true
+
+            .form-actions.text-right
+              = button_tag(type: 'submit', class: 'btn btn-primary', disabled: is_form_disabled?) do
+                = t('buttons.send_to_candidates')
+                = fa_icon('send', class: 'ml-1')

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -87,6 +87,7 @@ fr:
     search: "Rechercher"
     send: "Envoyer"
     send_to_candidate: "Envoyer au candidat"
+    send_to_candidates: "Envoyer aux candidat·es"
     send_unlock_instructions: "Envoyer les instructions de déblocage"
     show: "Voir"
     suspend: "Mettre en pause"
@@ -97,6 +98,7 @@ fr:
     unsuspend_user: "Réactiver"
     transfer: "Transférer"
     mark_as_read: "Marquer comme lu"
+    email: "Courriel"
   homepages:
     stepper:
       step_1: "Dépôt de la candidature"
@@ -455,6 +457,11 @@ fr:
         success: "Courriel marqué comme lu !"
       mark_as_unread:
         success: "Courriel marqué comme non lu !"
+    multiple_recipients_emails:
+      new:
+        title: "Envoyer un courriel à ces candidat·es"
+      create:
+        success: "Les emails ont été envoyés !"
     messages:
       create:
         success: "Message envoyé !"
@@ -1085,16 +1092,16 @@ fr:
         state: "État"
         state/start: "N'a encore aucune candidature"
         state/initial: "Nouveau"
-        state/rejected: "Refusé(e)"
+        state/rejected: "Refusé·e"
         state/phone_meeting: "Entretien téléphonique"
-        state/phone_meeting_rejected: "Refusé(e) après e. tél."
+        state/phone_meeting_rejected: "Refusé·e après e. tél."
         state/to_be_met: "À rencontrer"
-        state/after_meeting_rejected: "Rencontré(e) mais refusé(e)"
-        state/accepted: "Retenu(e)"
+        state/after_meeting_rejected: "Rencontré·e mais refusé·e"
+        state/accepted: "Retenu·e"
         state/contract_drafting: "Rédaction contrat"
-        state/contract_feedback_waiting: "En attente retour contrat"
+        state/contract_feedback_waiting: "Attente retour contrat"
         state/contract_received: "Contrat reçu"
-        state/affected: "Affecté(e)"
+        state/affected: "Affecté·e"
         state/end_user_state_0: "Candidature soumise"
         state/end_user_state_1: "Examen candidature"
         state/end_user_state_2: "Entretien téléphonique"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
           get :emails
         end
       end
+      resources :multiple_recipients_emails, only: %i[new create]
     end
     resources :preferred_users, only: :destroy
     resources :preferred_users_lists, path: "liste-candidats" do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -695,3 +695,33 @@ end
 ].each do |data|
   Department.create!(code: data[0], name: data[1], code_region: data[2], name_region: data[3])
 end
+
+EmailTemplate.create!(
+  [
+    {
+      title: "Courriel de proposition de rendez-vous téléphonique",
+      subject: "Votre candidature à l'offre XXXX de Civils de la Défense",
+      body: "Madame, Monsieur,\r\nJe vous confirme notre rendez-vous...\r\n\r\nSuite à votre candidature pour l'offre N° XXX..."
+    },
+    {
+      title: "Courriel candidature retenue et documents à fournir",
+      subject: "Votre candidature à l'offre XXXX de Civils de la Défense – Avis favorable au recrutement",
+      body: "Madame, Monsieur,\r\n\r\nJ’ai l’honneur de vous informer que, suite à votre dernier entretien, ..."
+    },
+    {
+      title: "Courriel précisions compétences",
+      subject: "Compétences",
+      body: "Nous souhaiterions avoir des précisions sur vos compétences."
+    },
+    {
+      title: "Courriel de refus",
+      subject: "Votre candidature à l'offre XXX Civils de la Défense ",
+      body: "Madame, Monsieur,\r\n\r\nNous avons bien reçu votre candidature et nous vous remercions de l'intérêt que vous ..."
+    },
+    {
+      title: "Courriel entretien tèl.",
+      subject: "Disponibilités",
+      body: "Pourriez-vous indiquer vos disponibilités ? "
+    }
+  ]
+)

--- a/spec/factories/job_offers.rb
+++ b/spec/factories/job_offers.rb
@@ -28,6 +28,12 @@ FactoryBot.define do
       state { :published }
     end
   end
+
+  trait :with_job_applications do
+    after(:create) do |job_offer|
+      3.times { job_offer.job_applications << create(:job_application) }
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :user do
     organization { Organization.first }
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    first_name { Faker::Name.unique.first_name }
+    last_name { Faker::Name.unique.last_name }
     current_position { "CEO" }
     phone { "06" }
     website_url { "MyString" }

--- a/spec/models/multiple_recipients_email_spec.rb
+++ b/spec/models/multiple_recipients_email_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MultipleRecipientsEmail do
+  it { should validate_presence_of(:subject) }
+  it { should validate_presence_of(:body) }
+  it { should validate_presence_of(:sender) }
+  it { should validate_presence_of(:job_application_ids) }
+
+  describe "#save" do
+    let(:job_offer) { create(:job_offer, :with_job_applications) }
+    let(:job_applications) { job_offer.job_applications }
+    let(:sender) { create(:administrator) }
+    subject {
+      MultipleRecipientsEmail.new(
+        subject: "subject",
+        body: "body",
+        job_application_ids: job_applications.pluck(:id),
+        sender: sender,
+        attachments: [
+          Rack::Test::UploadedFile.new(
+            Rails.root.join("spec/fixtures/files/document.pdf"),
+            "application/pdf"
+          )
+        ]
+      )
+    }
+
+    it "creates one email per job application" do
+      expect { subject.save }.to change { Email.count }.by(job_applications.size)
+    end
+
+    it "populates created emails with the right data" do
+      subject.save
+      job_applications.reload.each do |job_application|
+        email = job_application.emails.last
+        expect(email.sender).to eq(sender)
+        expect(email.subject).to eq("subject")
+        expect(email.body).to eq("body")
+        expect(email.email_attachments.count).to eq(1)
+      end
+    end
+
+    it "sends an email per job application" do
+      expect {
+        subject.save
+      }.to have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(job_applications.count).times
+    end
+  end
+end

--- a/spec/requests/admin/multiple_recipients_emails_spec.rb
+++ b/spec/requests/admin/multiple_recipients_emails_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "MultipleRecipientsEmails", type: :request do
+  let(:job_offer) { create(:job_offer, :with_job_applications) }
+  let(:job_applications) { job_offer.job_applications }
+
+  before { sign_in create(:administrator) }
+
+  describe "GET /new" do
+    it "shows the multiple recipients email form" do
+      get new_admin_job_offer_multiple_recipients_email_path(job_offer)
+      expect(response).to be_successful
+    end
+
+    it "filters recipients on the initial state when no state is given" do
+      get new_admin_job_offer_multiple_recipients_email_path(job_offer)
+      job_applications.initial.map(&:user).map(&:full_name).each do |name|
+        expect(response.body).to include(name)
+      end
+    end
+
+    it "filters recipients on the given state" do
+      job_applications << create(:job_application, state: :contract_received)
+
+      get new_admin_job_offer_multiple_recipients_email_path(job_offer, state: :contract_received)
+
+      job_applications.initial.map(&:user).map(&:full_name).each do |name|
+        expect(response.body).not_to include(name)
+      end
+
+      job_applications.contract_received.map(&:user).map(&:full_name).each do |name|
+        expect(response.body).to include(name)
+      end
+    end
+
+    it "filters out job applications with missing users" do
+      job_applications.last.user.destroy!
+
+      get new_admin_job_offer_multiple_recipients_email_path(job_offer)
+      job_applications.initial.with_user.map(&:user).map(&:full_name).each do |name|
+        expect(response.body).to include(name)
+      end
+    end
+
+    it "disables the form when the job offer is archived" do
+      get new_admin_job_offer_multiple_recipients_email_path(job_offer)
+      expect(response.body).not_to include("disabled")
+
+      job_offer.archive!
+
+      get new_admin_job_offer_multiple_recipients_email_path(job_offer)
+      expect(response.body).to include("disabled")
+    end
+  end
+
+  describe "POST /create" do
+    let(:params) {
+      {
+        multiple_recipients_email: {
+          job_application_ids: job_applications.pluck(:id),
+          subject: "subject",
+          body: "body",
+          attachments: [
+            Rack::Test::UploadedFile.new(
+              Rails.root.join("spec/fixtures/files/document.pdf"),
+              "application/pdf"
+            )
+          ]
+        }
+      }
+    }
+
+    it "creates emails" do
+      expect {
+        post admin_job_offer_multiple_recipients_emails_path(job_offer), params: params
+      }.to change { Email.count }.by(job_applications.count)
+
+      job_applications.reload.each do |job_application|
+        email = job_application.emails.last
+        expect(email.subject).to eq(params[:multiple_recipients_email][:subject])
+        expect(email.body).to eq(params[:multiple_recipients_email][:body])
+        expect(email.email_attachments.count).to eq(1)
+      end
+    end
+
+    it "sends emails" do
+      expect {
+        post admin_job_offer_multiple_recipients_emails_path(job_offer), params: params
+      }.to have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(job_applications.count).times
+    end
+
+    it "redirects to the job offer" do
+      post admin_job_offer_multiple_recipients_emails_path(job_offer), params: params
+      expect(response).to redirect_to([:board, :admin, job_offer])
+    end
+
+    describe "edge cases" do
+      context "when parameters are missing" do
+        let(:params) {
+          {
+            multiple_recipients_email: {
+              subject: "subject"
+            }
+          }
+        }
+
+        it "renders new with errors" do
+          post admin_job_offer_multiple_recipients_emails_path(job_offer), params: params
+          expect(response).to be_successful
+          expect(response.body).to include("Veuillez corriger les champs ci-dessous")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #1280 

On ajoute un écran pour envoyer simultanément un email à toutes les personnes d'une colonne donnée.

À cause du manque d'espace disponible, la fonctionnalité est disponible sous forme d'icône et le titre s'affiche en tooltip : 

![image](https://user-images.githubusercontent.com/1193334/175037412-12a584d0-1fd7-41a1-9ce3-62900dee5cbb.png)

À ce stade, les destinataires sont ceux de la colonne concernée : 

![image](https://user-images.githubusercontent.com/1193334/175037947-bb184b0f-4e0a-4057-aa0b-4eb8874a7b0b.png)
