### PR TITLE
fix: unreadable file

### DIFF
--- a/app/jobs/zip_job_application_files_job.rb
+++ b/app/jobs/zip_job_application_files_job.rb
@@ -38,8 +38,14 @@ class ZipJobApplicationFilesJob < ApplicationJob
       job_application.present?
     }.map { |job_application|
       job_application.job_application_files.select { |job_application_file|
-        job_application_file.content.present?
+        readable?(job_application_file)
       }
     }.flatten
+  end
+
+  def readable?(job_application_file)
+    job_application_file.content.present? && job_application_file.content.read
+  rescue NoMethodError
+    false
   end
 end


### PR DESCRIPTION
When a file can't be read (for example it is unreachable, empty or corrupted), it raises a "NoMethodError: undefined method `body' for nil:NilClass".
We catch it to skip the file in the zip archive.

Related to: https://sentry.incubateur.net/organizations/betagouv/issues/2981/?project=47&query=is%3Aunresolved

![image](https://user-images.githubusercontent.com/1193334/174972886-97d864d2-8058-4e71-abd9-ece58453eedf.png)
