### PR TITLE
feat: add and remove recipients

### DIFF
--- a/app/controllers/admin/recipients_controller.rb
+++ b/app/controllers/admin/recipients_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Admin::RecipientsController < Admin::BaseController
+  load_and_authorize_resource :job_offer
+
+  def index
+    respond_to do |format|
+      format.json {
+        render json: recipients(params[:s]).to_json(
+          only: :id,
+          include: {
+            user: {
+              only: %i[first_name last_name email]
+            }
+          }
+        )
+      }
+    end
+  end
+
+  def create
+  end
+
+  private
+
+  def recipient_params
+    params.require(:recipient).permit(:id).to_h.symbolize_keys
+  end
+
+  def recipients(query)
+    @job_offer.job_applications.search_users(query)
+  end
+end

--- a/app/javascript/controllers/add_recipient_controller.js
+++ b/app/javascript/controllers/add_recipient_controller.js
@@ -1,0 +1,75 @@
+import { Controller } from "@hotwired/stimulus"
+import { autocomplete } from '@algolia/autocomplete-js'
+
+export default class extends Controller {
+  static values = { searchUrl: String }
+  static targets = ["recipients", "autocomplete", "newRecipientForm", "newRecipientId"]
+
+  connect() {
+    autocomplete({
+      container: this.autocompleteTarget,
+      placeholder: 'Ajouter un·e destinataire',
+      detachedMediaQuery: 'none',
+      translations: {
+        clearButtonTitle: "Effacer",
+        submitButtonTitle: ""
+      },
+      getSources: ({ query }) => this.getSources(query)
+    })
+  }
+
+  // private
+
+  getSources(query) {
+    return fetch(`${this.searchUrlValue}?s=${query}`)
+      .then((response) => response.json())
+      .then((data) => {
+        return [
+          {
+            sourceId: `recipients`,
+            getItems: () => data,
+            templates: {
+              item: ({ item, html }) => this.templateItem(item, html),
+            },
+            onSelect: ({ item }) => this.add(item),
+          },
+        ]
+      })
+  }
+
+  add(recipient) {
+    if (!this.findRecipientIdInput(recipient.id)) {
+      this.newRecipientIdTarget.value = recipient.id
+      this.newRecipientFormTarget.requestSubmit()
+      this.newRecipientIdTarget.value = ""
+    }
+
+    this.clearSearch()
+  }
+
+  clearSearch() {
+    var clearButton = this.autocompleteTarget.querySelector(".aa-ClearButton")
+    if (clearButton) {
+      clearButton.click()
+    }
+  }
+
+  templateItem(item, html) {
+    return html`<div class="aa-ItemWrapper">
+      <div class="aa-ItemContent">
+        <div class="aa-ItemContentBody">
+          <span class="aa-ItemContentTitle">
+            ${item.user.first_name} ${item.user.last_name}
+          </span>
+          <span class="aa-ItemContentDescription">
+            ${item.user.email}
+          </span>
+        </div>
+      </div>
+    </div>`
+  }
+
+  findRecipientIdInput(id) {
+    return this.recipientsTargets.find(input => input.value === id)
+  }
+}

--- a/app/javascript/controllers/remove_recipient_controller.js
+++ b/app/javascript/controllers/remove_recipient_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["recipients"]
+
+  remove(event) {
+    this.removeRecipientFromRecipientsList(event.currentTarget)
+    this.removeRecipientIdFromEmailForm(event.params.id)
+  }
+
+  // private
+
+  removeRecipientFromRecipientsList(target) {
+    this.removeFromDOM(target.parentNode)
+  }
+
+  removeRecipientIdFromEmailForm(id) {
+    this.removeFromDOM(this.findRecipientIdInput(id))
+  }
+
+  findRecipientIdInput(id) {
+    return this.recipientsTargets.find(input => input.value === id)
+  }
+
+  removeFromDOM(target) {
+    target.parentNode.removeChild(target)
+  }
+}

--- a/app/javascript/css/autocomplete.scss
+++ b/app/javascript/css/autocomplete.scss
@@ -620,7 +620,7 @@ body {
     }
 
     @at-root .aa-ItemContentBody {
-      display: grid;
+      display: flex;
       gap: calc(var(--aa-spacing-half) / 2);
     }
 

--- a/app/javascript/css/autocomplete.scss
+++ b/app/javascript/css/autocomplete.scss
@@ -1,0 +1,1032 @@
+// ----------------
+// 1.  CSS Variables
+// 2.  Dark Mode
+// 3.  Autocomplete
+// 4.  Panel
+// 5.  Sources
+// 6.  Hit Layout
+// 7.  Panel Header
+// 8.  Panel Footer
+// 9.  Detached Mode
+// 10. Gradients
+// 11. Utilities
+// ----------------
+
+// Note:
+// This theme reflects the markup structure of autocomplete with SCSS indentation.
+// We use the SASS `@at-root` function to keep specificity low.
+
+// ----------------
+// 1. CSS Variables
+// ----------------
+:root {
+  // Input
+  --aa-search-input-height: 44px;
+  --aa-input-icon-size: 20px;
+
+  // Size and spacing
+  --aa-base-unit: 16;
+  --aa-spacing-factor: 1;
+  --aa-spacing: calc(var(--aa-base-unit) * var(--aa-spacing-factor) * 1px);
+  --aa-spacing-half: calc(var(--aa-spacing) / 2);
+  --aa-panel-max-height: 650px;
+
+  // Z-index
+  --aa-base-z-index: 9999;
+
+  // Font
+  --aa-font-size: calc(var(--aa-base-unit) * 1px);
+  --aa-font-family: inherit;
+  --aa-font-weight-medium: 400;
+    --aa-font-weight-semibold: 450;
+    --aa-font-weight-bold: 500;
+
+  // Icons
+  --aa-icon-size: 20px;
+  --aa-icon-stroke-width: 1.6;
+  --aa-icon-color-rgb: 73, 80, 87;
+  --aa-icon-color-alpha: 1;
+  --aa-action-icon-size: 20px;
+
+  // Text colors
+  --aa-text-color-rgb: 73, 80, 87;
+  --aa-text-color-alpha: 1;
+  --aa-primary-color-rgb: 0, 132, 248;
+  --aa-primary-color-alpha: 0.2;
+  --aa-muted-color-rgb: 196, 196, 196;
+  --aa-muted-color-alpha: 0.6;
+
+  // Border colors
+  --aa-panel-border-color-rgb: 0, 132, 248;
+  --aa-panel-border-color-alpha: 0.3;
+  --aa-input-border-color-rgb: 0, 132, 248;
+  --aa-input-border-color-alpha: 0.8;
+
+  // Background colors
+  --aa-background-color-rgb: 255, 255, 255;
+  --aa-background-color-alpha: 1;
+  --aa-input-background-color-rgb: 255, 255, 255;
+  --aa-input-background-color-alpha: 1;
+  --aa-selected-color-rgb: 0, 132, 248;
+  --aa-selected-color-alpha: 0.205;
+  --aa-description-highlight-background-color-rgb: 245, 223, 77;
+  --aa-description-highlight-background-color-alpha: 0.5;
+
+  // Detached mode
+  --aa-detached-media-query: (max-width: 680px);
+  --aa-detached-modal-media-query: (min-width: 680px);
+  --aa-detached-modal-max-width: 680px;
+  --aa-detached-modal-max-height: 500px;
+  --aa-overlay-color-rgb: 115, 114, 129;
+  --aa-overlay-color-alpha: 0.4;
+
+  // Shadows
+  --aa-panel-shadow: 0 0 0 1px rgba(35, 38, 59, 0.1),
+    0 6px 16px -4px rgba(35, 38, 59, 0.15);
+
+  // Scrollbar
+  --aa-scrollbar-width: 13px;
+  --aa-scrollbar-track-background-color-rgb: 234, 234, 234;
+  --aa-scrollbar-track-background-color-alpha: 1;
+  --aa-scrollbar-thumb-background-color-rgb: var(--aa-background-color-rgb);
+  --aa-scrollbar-thumb-background-color-alpha: 1;
+
+  // Touch screens
+  @media (hover: none) and (pointer: coarse) {
+    --aa-spacing-factor: 1.2;
+    --aa-action-icon-size: 22px;
+  }
+}
+
+// ----------------
+// 2. Dark Mode
+// ----------------
+body {
+
+  /* stylelint-disable selector-no-qualifying-type, selector-class-pattern */
+  &[data-theme='dark'],
+  &.dark {
+    // Text colors
+    --aa-text-color-rgb: 183, 192, 199;
+    --aa-primary-color-rgb: 146, 138, 255;
+    --aa-muted-color-rgb: 146, 138, 255;
+
+    // Background colors
+    --aa-input-background-color-rgb: 0, 3, 9;
+    --aa-background-color-rgb: 21, 24, 42;
+    --aa-selected-color-rgb: 146, 138, 255;
+    --aa-selected-color-alpha: 0.25;
+    --aa-description-highlight-background-color-rgb: 0 255 255;
+    --aa-description-highlight-background-color-alpha: 0.25;
+
+    // Icons
+    --aa-icon-color-rgb: 119, 119, 163;
+
+    // Shadows
+    --aa-panel-shadow: inset 1px 1px 0 0 rgb(44, 46, 64),
+      0 3px 8px 0 rgb(0, 3, 9);
+
+    // Scrollbar
+    --aa-scrollbar-track-background-color-rgb: 44, 46, 64;
+    --aa-scrollbar-thumb-background-color-rgb: var(--aa-background-color-rgb);
+  }
+
+  /* stylelint-enable selector-no-qualifying-type, selector-class-pattern */
+}
+
+// Reset for `@extend`
+%reset {
+  box-sizing: border-box;
+}
+
+// Init for `@extend`
+%init {
+  color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+  font-family: var(--aa-font-family);
+  font-size: var(--aa-font-size);
+  font-weight: normal;
+  line-height: 1em;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+
+// ----------------
+// 3. Autocomplete
+// ----------------
+.aa-Autocomplete,
+.aa-DetachedFormContainer {
+  @extend %init;
+
+  * {
+    @extend %reset;
+  }
+
+  // Search box
+  @at-root .aa-Form {
+    align-items: center;
+    background-color: rgba(var(--aa-input-background-color-rgb),
+        var(--aa-input-background-color-alpha));
+    border: 1px solid rgba(var(--aa-input-border-color-rgb), var(--aa-input-border-color-alpha));
+    display: flex;
+    line-height: 1em;
+    margin: 0;
+    position: relative;
+    width: 100%;
+
+    &:focus-within {
+      border-color: rgba(var(--aa-primary-color-rgb), 1);
+      box-shadow: rgba(var(--aa-primary-color-rgb),
+          var(--aa-primary-color-alpha)) 0 0 0 2px,
+        inset rgba(var(--aa-primary-color-rgb), var(--aa-primary-color-alpha)) 0 0 0 2px;
+      outline: currentColor none medium;
+    }
+
+    @at-root .aa-InputWrapperPrefix {
+      align-items: center;
+      display: flex;
+      flex-shrink: 0;
+      height: var(--aa-search-input-height);
+      order: 1;
+
+      // Container for search and loading icons
+      @at-root .aa-Label,
+      .aa-LoadingIndicator {
+        cursor: initial;
+        flex-shrink: 0;
+        height: 100%;
+        padding: 0;
+        text-align: left;
+
+        svg {
+          color: rgba(var(--aa-primary-color-rgb), 1);
+          height: auto;
+          max-height: var(--aa-input-icon-size);
+          stroke-width: var(--aa-icon-stroke-width);
+          width: var(--aa-input-icon-size);
+        }
+      }
+
+      @at-root .aa-SubmitButton,
+      .aa-LoadingIndicator {
+        height: 100%;
+        padding-left: calc(var(--aa-spacing) * 0.75 - 1px);
+        padding-right: var(--aa-spacing-half);
+        width: calc(var(--aa-spacing) * 1.75 + var(--aa-icon-size) - 1px);
+
+        @media (hover: none) and (pointer: coarse) {
+          padding-left: calc(var(--aa-spacing-half) / 2 - 1px);
+          width: calc(var(--aa-icon-size) + (var(--aa-spacing) * 1.25) - 1px);
+        }
+      }
+
+      @at-root .aa-SubmitButton {
+        appearance: none;
+        background: none;
+        border: 0;
+        margin: 0;
+      }
+
+      @at-root .aa-LoadingIndicator {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+
+        &[hidden] {
+          display: none;
+        }
+      }
+    }
+
+    @at-root .aa-InputWrapper {
+      order: 3;
+      position: relative;
+      width: 100%;
+
+      // Search box input (with placeholder and query)
+      @at-root .aa-Input {
+        appearance: none;
+        background: none;
+        border: 0;
+        color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+        font: inherit;
+        height: var(--aa-search-input-height);
+        padding: 0;
+        width: 100%;
+
+        &::placeholder {
+          color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
+          opacity: 1;
+        }
+
+        // Focus is set and styled on the parent, it isn't necessary here
+        &:focus {
+          border-color: none;
+          box-shadow: none;
+          outline: none;
+        }
+
+        // Remove native appearence
+        &::-webkit-search-decoration,
+        &::-webkit-search-cancel-button,
+        &::-webkit-search-results-button,
+        &::-webkit-search-results-decoration {
+          appearance: none;
+        }
+      }
+    }
+
+    @at-root .aa-InputWrapperSuffix {
+      align-items: center;
+      display: flex;
+      height: var(--aa-search-input-height);
+      order: 4;
+
+      // Accelerator to clear the query
+      @at-root .aa-ClearButton {
+        align-items: center;
+        background: none;
+        border: 0;
+        color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
+        cursor: pointer;
+        display: flex;
+        height: 100%;
+        margin: 0;
+        padding: 0 calc(var(--aa-spacing) * (5 / 6) - 0.5px);
+
+        @media (hover: none) and (pointer: coarse) {
+          padding: 0 calc(var(--aa-spacing) * (2 / 3) - 0.5px);
+        }
+
+        &:hover,
+        &:focus {
+          color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+        }
+
+        &[hidden] {
+          display: none;
+        }
+
+        svg {
+          stroke-width: var(--aa-icon-stroke-width);
+          width: var(--aa-icon-size);
+        }
+      }
+    }
+  }
+}
+
+// ----------------
+// 4. Panel
+// ----------------
+.aa-Panel {
+  @extend %init;
+
+  background-color: rgba(var(--aa-background-color-rgb),
+      var(--aa-background-color-alpha));
+  border-radius: calc(var(--aa-spacing) / 4);
+  box-shadow: var(--aa-panel-shadow);
+  margin: 8px 0 0;
+  overflow: hidden;
+  position: absolute;
+  transition: opacity 200ms ease-in, filter 200ms ease-in;
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
+  * {
+    @extend %reset;
+  }
+
+  button {
+    appearance: none;
+    background: none;
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  @at-root .aa-PanelLayout {
+    height: 100%;
+    margin: 0;
+    max-height: var(--aa-panel-max-height);
+    overflow-y: auto;
+    padding: 0;
+    position: relative;
+    text-align: left;
+
+    @at-root .aa-PanelLayoutColumns--twoGolden {
+      display: grid;
+      grid-template-columns: 39.2% auto;
+      overflow: hidden;
+      padding: 0;
+    }
+
+    @at-root .aa-PanelLayoutColumns--two {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      overflow: hidden;
+      padding: 0;
+    }
+
+    @at-root .aa-PanelLayoutColumns--three {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      overflow: hidden;
+      padding: 0;
+    }
+  }
+
+  // When a request isn't resolved yet
+  @at-root .aa-Panel--stalled {
+    .aa-Source {
+      filter: grayscale(1);
+      opacity: 0.8;
+    }
+  }
+
+  @at-root .aa-Panel--scrollable {
+    margin: 0;
+    max-height: var(--aa-panel-max-height);
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: var(--aa-spacing-half);
+    scrollbar-color: rgba(var(--aa-scrollbar-thumb-background-color-rgb),
+        var(--aa-scrollbar-thumb-background-color-alpha)) rgba(var(--aa-scrollbar-track-background-color-rgb),
+        var(--aa-scrollbar-track-background-color-alpha));
+    scrollbar-width: thin;
+
+    &::-webkit-scrollbar {
+      width: var(--aa-scrollbar-width);
+    }
+
+    &::-webkit-scrollbar-track {
+      background-color: rgba(var(--aa-scrollbar-track-background-color-rgb),
+          var(--aa-scrollbar-track-background-color-alpha));
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(var(--aa-scrollbar-thumb-background-color-rgb),
+          var(--aa-scrollbar-thumb-background-color-alpha));
+      border-color: rgba(var(--aa-scrollbar-track-background-color-rgb),
+          var(--aa-scrollbar-track-background-color-alpha));
+      border-radius: 9999px;
+      border-style: solid;
+      border-width: 3px 2px 3px 3px;
+    }
+  }
+}
+
+// ----------------
+// 5. Sources
+// Each source can be styled independently
+// ----------------
+.aa-Source {
+  margin: 0;
+  padding: 0;
+  position: relative;
+  width: 100%;
+
+  &:empty {
+    // Hide empty section
+    display: none;
+  }
+
+  @at-root .aa-SourceNoResults {
+    font-size: 1em;
+    margin: 0;
+    padding: var(--aa-spacing);
+  }
+
+  // List of results inside the source
+  @at-root .aa-List {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+  }
+
+  // Source title
+  @at-root .aa-SourceHeader {
+    margin: var(--aa-spacing-half) 0.5em var(--aa-spacing-half) 0;
+    padding: 0;
+    position: relative;
+
+    // Hide empty header
+    &:empty {
+      display: none;
+    }
+
+    // Title typography
+    @at-root .aa-SourceHeaderTitle {
+      background: rgba(var(--aa-background-color-rgb),
+          var(--aa-background-color-alpha));
+      color: rgba(var(--aa-primary-color-rgb), 1);
+      display: inline-block;
+      font-size: 0.8em;
+      font-weight: var(--aa-font-weight-semibold);
+      margin: 0;
+      padding: 0 var(--aa-spacing-half) 0 0;
+      position: relative;
+      z-index: var(--aa-base-z-index);
+    }
+
+    // Line separator
+    @at-root .aa-SourceHeaderLine {
+      border-bottom: solid 1px rgba(var(--aa-primary-color-rgb), 1);
+      display: block;
+      height: 2px;
+      left: 0;
+      margin: 0;
+      opacity: 0.3;
+      padding: 0;
+      position: absolute;
+      right: 0;
+      top: var(--aa-spacing-half);
+      z-index: calc(var(--aa-base-z-index) - 1);
+    }
+  }
+
+  // See all button
+  @at-root .aa-SourceFooterSeeAll {
+    background: linear-gradient(180deg,
+        rgba(var(--aa-background-color-rgb), var(--aa-background-color-alpha)),
+        rgba(128, 126, 163, 0.14));
+    border: 1px solid rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
+    border-radius: 5px;
+    box-shadow: inset 0 0 2px #fff, 0 2px 2px -1px rgba(76, 69, 88, 0.15);
+    color: inherit;
+    font-size: 0.95em;
+    font-weight: var(--aa-font-weight-medium);
+    padding: 0.475em 1em 0.6em;
+    text-decoration: none;
+
+    &:focus,
+    &:hover {
+      border: 1px solid rgba(var(--aa-primary-color-rgb), 1);
+      color: rgba(var(--aa-primary-color-rgb), 1);
+    }
+  }
+}
+
+// ----------------
+// 6. Hit Layout
+// ----------------
+.aa-Item {
+  align-items: center;
+  border-radius: 3px;
+  cursor: pointer;
+  display: grid;
+  min-height: calc(var(--aa-spacing) * 2.5);
+  padding: calc(var(--aa-spacing-half) / 2);
+
+  // When the result is active
+  &[aria-selected='true'] {
+    background-color: rgba(var(--aa-selected-color-rgb),
+        var(--aa-selected-color-alpha));
+
+    .aa-ItemActionButton,
+    .aa-ActiveOnly {
+      visibility: visible;
+    }
+  }
+
+  // The result type icon inlined SVG or image
+  @at-root .aa-ItemIcon {
+    align-items: center;
+    background: rgba(var(--aa-background-color-rgb),
+        var(--aa-background-color-alpha));
+    border-radius: 3px;
+    box-shadow: inset 0 0 0 1px rgba(var(--aa-panel-border-color-rgb), var(--aa-panel-border-color-alpha));
+    color: rgba(var(--aa-icon-color-rgb), var(--aa-icon-color-alpha));
+    display: flex;
+    flex-shrink: 0;
+    font-size: 0.7em;
+    height: calc(var(--aa-icon-size) + var(--aa-spacing-half));
+    justify-content: center;
+    overflow: hidden;
+    stroke-width: var(--aa-icon-stroke-width);
+    text-align: center;
+    width: calc(var(--aa-icon-size) + var(--aa-spacing-half));
+
+    img {
+      height: auto;
+      max-height: calc(var(--aa-icon-size) + var(--aa-spacing-half) - 8px);
+      max-width: calc(var(--aa-icon-size) + var(--aa-spacing-half) - 8px);
+      width: auto;
+    }
+
+    svg {
+      height: var(--aa-icon-size);
+      width: var(--aa-icon-size);
+    }
+
+    @at-root .aa-ItemIcon--alignTop {
+      align-self: flex-start;
+    }
+
+    @at-root .aa-ItemIcon--noBorder {
+      background: none;
+      box-shadow: none;
+    }
+
+    @at-root .aa-ItemIcon--picture {
+      height: 96px;
+      width: 96px;
+
+      img {
+        max-height: 100%;
+        max-width: 100%;
+        padding: var(--aa-spacing-half);
+      }
+    }
+  }
+
+  @at-root .aa-ItemContent {
+    align-items: center;
+    cursor: pointer;
+    display: grid;
+    gap: var(--aa-spacing-half);
+    grid-auto-flow: column;
+    line-height: 1.25em;
+    overflow: hidden;
+
+    &:empty {
+      display: none;
+    }
+
+    mark {
+      background: none;
+      color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+      font-style: normal;
+      font-weight: var(--aa-font-weight-bold);
+    }
+
+    @at-root .aa-ItemContent--dual {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      text-align: left;
+
+      .aa-ItemContentTitle,
+      .aa-ItemContentSubtitle {
+        display: block;
+      }
+    }
+
+    @at-root .aa-ItemContent--indented {
+      padding-left: calc(var(--aa-icon-size) + var(--aa-spacing));
+    }
+
+    @at-root .aa-ItemContentBody {
+      display: grid;
+      gap: calc(var(--aa-spacing-half) / 2);
+    }
+
+    @at-root .aa-ItemContentTitle {
+      display: inline-block;
+      margin: 0 0.5em 0 0;
+      max-width: 100%;
+      overflow: hidden;
+      padding: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    @at-root .aa-ItemContentSubtitle {
+      font-size: 0.92em;
+
+      @at-root .aa-ItemContentSubtitleIcon {
+        &::before {
+          border-color: rgba(var(--aa-muted-color-rgb), 0.64);
+          border-style: solid;
+          content: '';
+          display: inline-block;
+          left: 1px;
+          position: relative;
+          top: -3px;
+        }
+      }
+
+      @at-root .aa-ItemContentSubtitle--inline {
+        .aa-ItemContentSubtitleIcon {
+          &::before {
+            border-width: 0 0 1.5px;
+            margin-left: var(--aa-spacing-half);
+            margin-right: calc(var(--aa-spacing-half) / 2);
+            width: calc(var(--aa-spacing-half) + 2px);
+          }
+        }
+      }
+
+      @at-root .aa-ItemContentSubtitle--standalone {
+        align-items: center;
+        color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+        display: grid;
+        gap: var(--aa-spacing-half);
+        grid-auto-flow: column;
+        justify-content: start;
+
+        .aa-ItemContentSubtitleIcon {
+          &::before {
+            border-radius: 0 0 0 3px;
+            border-width: 0 0 1.5px 1.5px;
+            height: var(--aa-spacing-half);
+            width: var(--aa-spacing-half);
+          }
+        }
+      }
+
+      @at-root .aa-ItemContentSubtitleCategory {
+        color: rgba(var(--aa-muted-color-rgb), 1);
+        font-weight: 500;
+      }
+    }
+
+    @at-root .aa-ItemContentDescription {
+      color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+      font-size: 0.85em;
+      max-width: 100%;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+
+      &:empty {
+        display: none;
+      }
+
+      mark {
+        background: rgba(var(--aa-description-highlight-background-color-rgb),
+            var(--aa-description-highlight-background-color-alpha));
+        color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+        font-style: normal;
+        font-weight: var(--aa-font-weight-medium);
+      }
+    }
+
+    @at-root .aa-ItemContentDash {
+      color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
+      display: none;
+      opacity: 0.4;
+    }
+
+    @at-root .aa-ItemContentTag {
+      background-color: rgba(var(--aa-primary-color-rgb),
+          var(--aa-primary-color-alpha));
+      border-radius: 3px;
+      margin: 0 0.4em 0 0;
+      padding: 0.08em 0.3em;
+    }
+  }
+
+  // wrap hit with url but we don't need to see it
+  @at-root .aa-ItemWrapper,
+  .aa-ItemLink {
+    align-items: center;
+    color: inherit;
+    display: grid;
+    gap: calc(var(--aa-spacing-half) / 2);
+    grid-auto-flow: column;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  @at-root .aa-ItemLink {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  // Secondary click actions
+  @at-root .aa-ItemActions {
+    display: grid;
+    grid-auto-flow: column;
+    height: 100%;
+    justify-self: end;
+    margin: 0 calc(var(--aa-spacing) / -3);
+    padding: 0 2px 0 0;
+  }
+
+  @at-root .aa-ItemActionButton {
+    align-items: center;
+    background: none;
+    border: 0;
+    color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
+    cursor: pointer;
+    display: flex;
+    flex-shrink: 0;
+    padding: 0;
+
+    &:hover,
+    &:focus {
+      svg {
+        color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+
+        @media (hover: none) and (pointer: coarse) {
+          color: inherit;
+        }
+      }
+    }
+
+    svg {
+      color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
+      margin: 0;
+      margin: calc(var(--aa-spacing) / 3);
+      stroke-width: var(--aa-icon-stroke-width);
+      width: var(--aa-action-icon-size);
+    }
+  }
+
+  @at-root .aa-ActiveOnly {
+    visibility: hidden;
+  }
+}
+
+//----------------
+// 7. Panel Header
+//----------------
+.aa-PanelHeader {
+  align-items: center;
+  background: rgba(var(--aa-primary-color-rgb), 1);
+  color: #fff;
+  display: grid;
+  height: var(--aa-modal-header-height);
+  margin: 0;
+  padding: var(--aa-spacing-half) var(--aa-spacing);
+  position: relative;
+
+  &::after {
+    background-image: linear-gradient(rgba(var(--aa-background-color-rgb), 1),
+        rgba(var(--aa-background-color-rgb), 0));
+    bottom: calc(var(--aa-spacing-half) * -1);
+    content: '';
+    height: var(--aa-spacing-half);
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    z-index: var(--aa-base-z-index);
+  }
+}
+
+//----------------
+// 8. Panel Footer
+//----------------
+.aa-PanelFooter {
+  background-color: rgba(var(--aa-background-color-rgb),
+      var(--aa-background-color-alpha));
+  box-shadow: inset 0 1px 0 rgba(var(--aa-panel-border-color-rgb), var(--aa-panel-border-color-alpha));
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  padding: var(--aa-spacing);
+  position: relative;
+  z-index: var(--aa-base-z-index);
+
+  &::after {
+    background-image: linear-gradient(rgba(var(--aa-background-color-rgb), 0),
+        rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha)));
+    content: '';
+    height: var(--aa-spacing);
+    left: 0;
+    opacity: 0.12;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: calc(var(--aa-spacing) * -1);
+    z-index: calc(var(--aa-base-z-index) - 1);
+  }
+}
+
+//----------------
+// 9. Detached Mode
+//----------------
+.aa-DetachedContainer {
+  background: rgba(var(--aa-background-color-rgb),
+      var(--aa-background-color-alpha));
+  bottom: 0;
+  box-shadow: var(--aa-panel-shadow);
+  display: flex;
+  flex-direction: column;
+  left: 0;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: var(--aa-base-z-index);
+
+  &::after {
+    height: 32px;
+  }
+
+  .aa-SourceHeader {
+    margin: var(--aa-spacing-half) 0 var(--aa-spacing-half) 2px;
+  }
+
+  .aa-Panel {
+    background-color: rgba(var(--aa-background-color-rgb),
+        var(--aa-background-color-alpha));
+    border-radius: 0;
+    box-shadow: none;
+    flex-grow: 1;
+    margin: 0;
+    padding: 0;
+    position: relative;
+  }
+
+  .aa-PanelLayout {
+    bottom: 0;
+    box-shadow: none;
+    left: 0;
+    margin: 0;
+    max-height: none;
+    overflow-y: auto;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 100%;
+  }
+
+  @at-root .aa-DetachedFormContainer {
+    border-bottom: solid 1px rgba(var(--aa-panel-border-color-rgb), var(--aa-panel-border-color-alpha));
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 0;
+    padding: var(--aa-spacing-half);
+
+    @at-root .aa-DetachedCancelButton {
+      background: none;
+      border: 0;
+      border-radius: 3px;
+      color: inherit;
+      color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
+      cursor: pointer;
+      font: inherit;
+      margin: 0 0 0 var(--aa-spacing-half);
+      padding: 0 var(--aa-spacing-half);
+
+      &:hover,
+      &:focus {
+        box-shadow: inset 0 0 0 1px rgba(var(--aa-panel-border-color-rgb),
+            var(--aa-panel-border-color-alpha));
+      }
+    }
+  }
+
+  @at-root .aa-DetachedContainer--modal {
+    border-radius: 6px;
+    bottom: inherit;
+    height: auto;
+    margin: 0 auto;
+    max-width: var(--aa-detached-modal-max-width);
+    position: absolute;
+    top: 3%;
+
+    .aa-PanelLayout {
+      max-height: var(--aa-detached-modal-max-height);
+      padding-bottom: var(--aa-spacing-half);
+      position: static;
+    }
+  }
+}
+
+// Search Button
+.aa-DetachedSearchButton {
+  align-items: center;
+  background-color: rgba(var(--aa-input-background-color-rgb),
+      var(--aa-input-background-color-alpha));
+  border: 1px solid rgba(var(--aa-input-border-color-rgb), var(--aa-input-border-color-alpha));
+  border-radius: 3px;
+  color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-family: var(--aa-font-family);
+  font-size: var(--aa-font-size);
+  height: var(--aa-search-input-height);
+  margin: 0;
+  padding: 0 calc(var(--aa-search-input-height) / 8);
+  position: relative;
+  text-align: left;
+  width: 100%;
+
+  &:focus {
+    border-color: rgba(var(--aa-primary-color-rgb), 1);
+    box-shadow: rgba(var(--aa-primary-color-rgb), var(--aa-primary-color-alpha)) 0 0 0 3px,
+      inset rgba(var(--aa-primary-color-rgb), var(--aa-primary-color-alpha)) 0 0 0 2px;
+    outline: currentColor none medium;
+  }
+
+  @at-root .aa-DetachedSearchButtonIcon {
+    align-items: center;
+    color: rgba(var(--aa-primary-color-rgb), 1);
+    cursor: initial;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    width: calc(var(--aa-icon-size) + var(--aa-spacing));
+  }
+}
+
+// Remove scroll on `body`
+.aa-Detached {
+  height: 100vh;
+  overflow: hidden;
+}
+
+.aa-DetachedOverlay {
+  background-color: rgba(var(--aa-overlay-color-rgb),
+      var(--aa-overlay-color-alpha));
+  height: 100vh;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: calc(var(--aa-base-z-index) - 1);
+}
+
+//----------------
+// 10. Gradients
+//----------------
+.aa-GradientTop,
+.aa-GradientBottom {
+  height: var(--aa-spacing-half);
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  z-index: var(--aa-base-z-index);
+}
+
+.aa-GradientTop {
+  background-image: linear-gradient(rgba(var(--aa-background-color-rgb), 1),
+      rgba(var(--aa-background-color-rgb), 0));
+  top: 0;
+}
+
+.aa-GradientBottom {
+  background-image: linear-gradient(rgba(var(--aa-background-color-rgb), 0),
+      rgba(var(--aa-background-color-rgb), 1));
+  border-bottom-left-radius: calc(var(--aa-spacing) / 4);
+  border-bottom-right-radius: calc(var(--aa-spacing) / 4);
+  bottom: 0;
+}
+
+//----------------
+// 11. Utilities
+//----------------
+.aa-DesktopOnly {
+  @media (hover: none) and (pointer: coarse) {
+    display: none;
+  }
+}
+
+.aa-TouchOnly {
+  @media (hover: hover) {
+    display: none;
+  }
+}

--- a/app/javascript/packs/admin-style.js
+++ b/app/javascript/packs/admin-style.js
@@ -3,3 +3,4 @@ import 'lightpick/css/lightpick.css'
 import 'trix/dist/trix.css'
 import 'node-snackbar/dist/snackbar.css'
 require('css/admin.scss')
+require('css/autocomplete.scss')

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -19,6 +19,14 @@ class JobApplication < ApplicationRecord
       user: %i[first_name last_name],
       job_offer: %i[identifier title]
     }
+  pg_search_scope :search_users,
+    ignoring: :accents,
+    associated_against: {
+      user: %i[email first_name last_name]
+    },
+    using: {
+      tsearch: {prefix: true, any_word: true}
+    }
 
   belongs_to :job_offer
   belongs_to :organization

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Recipient
+  include ActiveModel::Model
+
+  attr_accessor :id
+  attr_reader :user
+
+  def initialize(id: nil)
+    @id = id
+    @user = JobApplication.find(@id).user if @id.present?
+  end
+end

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -41,15 +41,17 @@
                           = f.association :employer, collection: employers.map{|x| [x.code, x.id]}, disabled: true, include_blank: false
                       .col-12.col-md-3
                         = f.association :bop
-                    .row
-                      .col-12.col-md-6{data: { controller: 'autocomplete-city' }}
-                        = f.input :location, input_html: { 'data-autocomplete-city-target' => :query }
+                    .row{data: { controller: 'autocomplete-city' }}
+                      .col-12.col-md-6
+                        = f.input :location, input_html: { 'data-autocomplete-city-target' => :location, 'data-action' => "click->autocomplete-city#search" }
                         = f.input :city, as: :hidden, input_html: { 'data-autocomplete-city-target' => :city }
                         = f.input :county, as: :hidden, input_html: { 'data-autocomplete-city-target' => :county }
                         = f.input :county_code, as: :hidden, input_html: { 'data-autocomplete-city-target' => :countyCode }
                         = f.input :country_code, as: :hidden, input_html: { 'data-autocomplete-city-target' => :countryCode }
                         = f.input :postcode, as: :hidden, input_html: { 'data-autocomplete-city-target' => :postcode }
                         = f.input :region, as: :hidden, input_html: { 'data-autocomplete-city-target' => :region }
+                        .d-none
+                          .autocomplete{ 'data-autocomplete-city-target' => :query }
                       - if current_administrator.bant?
                         .col-12.col-md-6
                           = f.input :spontaneous

--- a/app/views/admin/multiple_recipients_emails/_job_application_id.html.haml
+++ b/app/views/admin/multiple_recipients_emails/_job_application_id.html.haml
@@ -1,0 +1,1 @@
+= hidden_field_tag "multiple_recipients_email[job_application_ids][]", job_application.id, multiple: true, data: {remove_recipient_target: "recipients", add_recipient_target: "recipients"}

--- a/app/views/admin/multiple_recipients_emails/_recipient.html.haml
+++ b/app/views/admin/multiple_recipients_emails/_recipient.html.haml
@@ -1,0 +1,4 @@
+%li.list-inline-item.border.rounded
+  = job_application.user.full_name
+  = button_tag type: 'button', title: t("buttons.delete"), class: "btn btn-link mb-0 px-0 py-0", data: {action: "click->remove-recipient#remove", remove_recipient_id_param: job_application.id} do
+    = fa_icon("delete")

--- a/app/views/admin/multiple_recipients_emails/_recipients.html.haml
+++ b/app/views/admin/multiple_recipients_emails/_recipients.html.haml
@@ -1,0 +1,6 @@
+%ul.list-inline{id: dom_id(job_offer, 'recipients')}
+  - for job_application in job_applications
+    = render partial: "recipient", locals: {job_application: job_application}
+.autocomplete{data: {add_recipient_target: "autocomplete"}}
+= simple_form_for([:admin, job_offer, Recipient.new], remote: true, data: {add_recipient_target: "newRecipientForm"}, html: {class: "d-none"}) do |f|
+  = f.input :id, input_html: {data: {add_recipient_target: "newRecipientId"}}

--- a/app/views/admin/multiple_recipients_emails/new.html.haml
+++ b/app/views/admin/multiple_recipients_emails/new.html.haml
@@ -1,15 +1,14 @@
 .container-fluid.pt-3
   .row 
     .col-12.col-md-10.mx-md-auto
-      .card
+      .card{data: {controller: "remove-recipient"}}
         .card-header.bg-white.font-weight-bold.text-secondary
           = fa_icon('file-document', class: 'text-secondary')
           = t('.title')
-        .card-subheader.bg-card-bg.font-weight-bold.text-muted
+        .card-subheader.bg-card-bg
           %ul.list-inline
             - for job_application in @job_applications
-              %li.list-inline-item
-                = job_application.user.full_name
+              = render partial: "recipient", locals: { job_application: job_application }
         .card-body.bg-white
           = simple_form_for(:email, url: [:admin, :email_templates], method: :get, remote: true, html: {id: :email_template_selector, class: 'auto-submit'}, defaults: { disabled: is_form_disabled? }) do |f|
             .form-inputs
@@ -21,7 +20,7 @@
 
             .form-inputs
               - for job_application in @job_applications
-                = f.hidden_field :job_application_ids, value: job_application.id, multiple: true
+                = f.hidden_field :job_application_ids, value: job_application.id, multiple: true, data: {remove_recipient_target: "recipients"}
               = f.input :subject
               = f.input :body, as: :text
               = f.file_field :attachments, multiple: true

--- a/app/views/admin/multiple_recipients_emails/new.html.haml
+++ b/app/views/admin/multiple_recipients_emails/new.html.haml
@@ -1,26 +1,24 @@
 .container-fluid.pt-3
   .row 
     .col-12.col-md-10.mx-md-auto
-      .card{data: {controller: "remove-recipient"}}
+      .card{data: {controller: "remove-recipient add-recipient", add_recipient_search_url_value: admin_job_offer_recipients_path(@job_offer, format: :json)}}
         .card-header.bg-white.font-weight-bold.text-secondary
           = fa_icon('file-document', class: 'text-secondary')
           = t('.title')
         .card-subheader.bg-card-bg
-          %ul.list-inline
-            - for job_application in @job_applications
-              = render partial: "recipient", locals: { job_application: job_application }
+          = render partial: "recipients", locals: { job_offer: @job_offer, job_applications: @job_applications}
         .card-body.bg-white
           = simple_form_for(:email, url: [:admin, :email_templates], method: :get, remote: true, html: {id: :email_template_selector, class: 'auto-submit'}, defaults: { disabled: is_form_disabled? }) do |f|
             .form-inputs
-              = f.input :template, collection: EmailTemplate.all
+              = f.input :template, required: false, collection: EmailTemplate.all
 
           = simple_form_for([:admin, @job_offer, @multiple_recipients_email], defaults: { disabled: is_form_disabled? }) do |f|
             = f.error_notification 
             = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
 
-            .form-inputs
+            .form-inputs{id: dom_id(@job_offer, 'job_application_ids')}
               - for job_application in @job_applications
-                = f.hidden_field :job_application_ids, value: job_application.id, multiple: true, data: {remove_recipient_target: "recipients"}
+                = render partial: "job_application_id", locals: {job_application: job_application}
               = f.input :subject
               = f.input :body, as: :text
               = f.file_field :attachments, multiple: true

--- a/app/views/admin/recipients/create.js.erb
+++ b/app/views/admin/recipients/create.js.erb
@@ -1,0 +1,7 @@
+var recipientsNode = document.getElementById('<%= dom_id(@job_offer, 'recipients') %>')
+var recipientHtml = '<%= j render(partial: '/admin/multiple_recipients_emails/recipient', locals: { job_application: @recipient}) %>'
+recipientsNode.appendChild(document.createRange().createContextualFragment(recipientHtml))
+
+var jobApplicationIdsNode = document.getElementById('<%= dom_id(@job_offer, 'job_application_ids') %>')
+var jobApplicationIdHtml = '<%= j render(partial: '/admin/multiple_recipients_emails/job_application_id', locals: { job_application: @recipient}) %>'
+jobApplicationIdsNode.appendChild(document.createRange().createContextualFragment(jobApplicationIdHtml))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
         end
       end
       resources :multiple_recipients_emails, only: %i[new create]
+      resources :recipients, only: %i[index create]
     end
     resources :preferred_users, only: :destroy
     resources :preferred_users_lists, path: "liste-candidats" do

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "civilsdeladefense",
   "private": true,
   "dependencies": {
+    "@algolia/autocomplete-js": "^1.7.1",
     "@gouvfr/all": "^0.5.3",
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@hotwired/turbo-rails": "^7.0.0-beta.5",
     "@rails/ujs": "^6.1.3",
     "@rails/webpacker": "^5.2.1",
-    "autocomplete.js": "^0.38.0",
     "bootstrap": "^4.3.1",
     "bootstrap-material-design": "^4.1.2",
     "bootstrap.native": "=3.0.14",

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Recipient, type: :model do
+  it "loads the user when instiated with an id" do
+    job_application = create(:job_application)
+    expect(Recipient.new(id: job_application.id).user).to be_present
+  end
+end

--- a/spec/requests/admin/recipients_spec.rb
+++ b/spec/requests/admin/recipients_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::RecipientsController, type: :request do
+  let(:job_offer) { create(:job_offer) }
+
+  before { sign_in create(:administrator) }
+
+  describe "GET /index" do
+    let(:user_a) { create(:user, first_name: "Grant", last_name: "Hill") }
+    let(:user_b) { create(:user, first_name: "Hugh", last_name: "Grant") }
+    let(:user_c) { create(:user, email: "totoro@miyazaki.jp") }
+    let!(:job_application_a) { create(:job_application, job_offer: job_offer, user: user_a) }
+    let!(:job_application_b) { create(:job_application, job_offer: job_offer, user: user_b) }
+    let!(:job_application_c) { create(:job_application, job_offer: job_offer, user: user_c) }
+
+    it "is successful" do
+      get admin_job_offer_recipients_path(job_offer, format: :json, s: "aaa")
+      expect(response).to be_successful
+    end
+
+    it "returns an empty array when the search string is missing" do
+      get admin_job_offer_recipients_path(job_offer, format: :json)
+      expect(JSON.parse(response.body)).to eq([])
+    end
+
+    it "returns no results when the search string doesn't match any recipients" do
+      get admin_job_offer_recipients_path(job_offer, format: :json, s: "aaa")
+      expect(JSON.parse(response.body)).to eq([])
+    end
+
+    it "searches for matching recipients (aka job applications which user name matches the query)" do
+      get admin_job_offer_recipients_path(job_offer, format: :json, s: "Grant")
+      expect(JSON.parse(response.body)).to match([
+        {
+          id: job_application_b.id,
+          user: {first_name: user_b.first_name, last_name: user_b.last_name, email: user_b.email}
+        }.with_indifferent_access,
+        {
+          id: job_application_a.id,
+          user: {first_name: user_a.first_name, last_name: user_a.last_name, email: user_a.email}
+        }.with_indifferent_access
+      ])
+    end
+
+    it "searches for a given recipient, by name (aka job applications which user name matches the query)" do
+      get admin_job_offer_recipients_path(job_offer, format: :json, s: "Hugh")
+      expect(JSON.parse(response.body)).to match([
+        {
+          id: job_application_b.id,
+          user: {first_name: user_b.first_name, last_name: user_b.last_name, email: user_b.email}
+        }.with_indifferent_access
+      ])
+    end
+
+    it "searches for a given recipient, by email (aka job applications which user name matches the query)" do
+      get admin_job_offer_recipients_path(job_offer, format: :json, s: "totoro")
+      expect(JSON.parse(response.body)).to match([
+        {
+          id: job_application_c.id,
+          user: {first_name: user_c.first_name, last_name: user_c.last_name, email: user_c.email}
+        }.with_indifferent_access
+      ])
+    end
+  end
+
+  describe "POST /index" do
+    let!(:job_application) { create(:job_application, job_offer: job_offer) }
+
+    it "is successful" do
+      post admin_job_offer_recipients_path(job_offer), xhr: true, params: {recipient: {id: job_application.id}}
+      expect(response).to be_successful
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,13 +1876,6 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autocomplete.js@^0.38.0:
-  version "0.38.1"
-  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.38.1.tgz#9b006c985d996165ebbc62af33f5b4c32d209cc2"
-  integrity sha512-6pSJzuRMY3pqpozt+SXThl2DmJfma8Bi3SVFbZHS0PW/N72bOUv+Db0jAh2cWOhTsA4X+GNmKvIl8wExJTnN9w==
-  dependencies:
-    immediate "^3.2.3"
-
 autoprefixer@^9.6.1:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
@@ -4021,11 +4014,6 @@ image-size@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
-
-immediate@^3.2.3:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
-  integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
 
 import-cwd@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,36 @@
 # yarn lockfile v1
 
 
+"@algolia/autocomplete-core@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz#025538b8a9564a9f3dd5bcf8a236d6951c76c7d1"
+  integrity sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.7.1"
+
+"@algolia/autocomplete-js@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-js/-/autocomplete-js-1.7.1.tgz#4cb41eb916cc83d67a96294916ceb86c8200946e"
+  integrity sha512-m8xQiH1qdthovVOD9O8/ur9P5us+sljskIpB1HFQIFmsfchorJNFlpMT+zE8V55tbJOwusUrp85c9t+6lkOllg==
+  dependencies:
+    "@algolia/autocomplete-core" "1.7.1"
+    "@algolia/autocomplete-preset-algolia" "1.7.1"
+    "@algolia/autocomplete-shared" "1.7.1"
+    htm "^3.0.0"
+    preact "^10.0.0"
+
+"@algolia/autocomplete-preset-algolia@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz#7dadc5607097766478014ae2e9e1c9c4b3f957c8"
+  integrity sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.7.1"
+
+"@algolia/autocomplete-shared@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz#95c3a0b4b78858fed730cf9c755b7d1cd0c82c74"
+  integrity sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
@@ -3870,6 +3900,11 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+htm@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-3.1.1.tgz#49266582be0dc66ed2235d5ea892307cc0c24b78"
+  integrity sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
@@ -6155,6 +6190,11 @@ posthtml@^0.9.2:
   dependencies:
     posthtml-parser "^0.2.0"
     posthtml-render "^1.0.5"
+
+preact@^10.0.0:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.8.2.tgz#b8a614f5cc8ab0cd9e63337a3d60dc80410f4ed4"
+  integrity sha512-AKGt0BsDSiAYzVS78jZ9qRwuorY2CoSZtf1iOC6gLb/3QyZt+fLT09aYJBjRc/BEcRc4j+j3ggERMdNE43i1LQ==
 
 prepend-http@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
closes #1294

On commence par ajouter la nouvelle version de la libraire `algolia/autocomplete-js`, destinée à remplacer celle du projet (`autocomplete.js`).

Ensuite, on permet la suppression, puis l'ajout, de destinataires : 
![image](https://user-images.githubusercontent.com/1193334/176661104-0eb02b11-5966-4517-b60c-c49b79296f4d.png)
![image](https://user-images.githubusercontent.com/1193334/176661291-0bdcd0e8-3230-48c3-93a0-4e37a470a124.png)

Enfin, sur l'écran de création de `JobOffer`, on remplace `autocomplete.js` par `algolia/autocomplete-js` : 
![Capture d’écran du 2022-06-30 13-01-21](https://user-images.githubusercontent.com/1193334/176661660-c4242af3-4fd5-4135-8d14-0a1fea6b7a87.png)
