### PR TITLE
fix: transfer to a new admin with invalid email

### DIFF
--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -118,13 +118,12 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
   end
 
   # POST /admin/settings/administrators/1/transfer
-  # POST /admin/settings/administrators/1/transfer.json
   def transfer
-    @administrator.transfer!(params[:transfer_email])
-
-    respond_to do |format|
-      format.html { redirect_to %i[admin settings root], notice: t(".success") }
-      format.json { render :show, status: :ok, location: @administrator }
+    transfer = @administrator.transfer(params[:transfer_email])
+    if transfer.persisted?
+      redirect_to %i[admin settings root], notice: t(".success")
+    else
+      redirect_to [:edit, :admin, :settings, @administrator], notice: transfer.errors.full_messages.to_sentence
     end
   end
 

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -181,13 +181,15 @@ class Administrator < ApplicationRecord
     end
   end
 
-  def transfer!(email)
+  def transfer(email)
     administrator = Administrator.find_by(email: email.downcase) || Administrator.new(email: email)
     administrator.inviter ||= self
     administrator.organization = organization
-    administrator.save!
-    job_offer_actors.update_all(administrator_id: administrator.id)
-    owned_job_offers.update_all(owner_id: administrator.id)
+    if administrator.save
+      job_offer_actors.update_all(administrator_id: administrator.id)
+      owned_job_offers.update_all(owner_id: administrator.id)
+    end
+    administrator
   end
 
   def password_complexity


### PR DESCRIPTION
See https://sentry.incubateur.net/organizations/betagouv/issues/3489/?project=47&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox

The transfer to a new admin used to crash when the email was invalid,
because of a `save!`.
Here we manage this case smoothly.

