### PR TITLE
fix: don't crash when the ZipFile already exists

### DIFF
--- a/app/jobs/zip_job_application_files_job.rb
+++ b/app/jobs/zip_job_application_files_job.rb
@@ -4,7 +4,7 @@ class ZipJobApplicationFilesJob < ApplicationJob
   queue_as :default
 
   def perform(zip_id:, user_ids:)
-    zip_file = ZipFile.create!(id: zip_id)
+    zip_file = ZipFile.first_or_create(id: zip_id)
     zip_file.zip = Pathname.new(Rails.root.join(zip(zip_id, job_application_files(user_ids)))).open
     zip_file.save!
   end

--- a/spec/jobs/zip_job_application_files_job_spec.rb
+++ b/spec/jobs/zip_job_application_files_job_spec.rb
@@ -34,5 +34,13 @@ RSpec.describe ZipJobApplicationFilesJob, type: :job do
         ZipJobApplicationFilesJob.new.perform(zip_id: id, user_ids: [user.id])
       }.not_to raise_error
     end
+
+    it "doesn't crash when the zip file already exists" do
+      ZipJobApplicationFilesJob.new.perform(zip_id: id, user_ids: [user.id])
+
+      expect {
+        ZipJobApplicationFilesJob.new.perform(zip_id: id, user_ids: [user.id])
+      }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
See https://sentry.incubateur.net/organizations/betagouv/issues/2995/?project=47&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox