### PR TITLE
feat: user is timeoutable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
 
   include ErrorResponseActions
   include SentryIdentifier
+  include Timeoutable
 
   rescue_from CanCan::AccessDenied, with: :authorization_error
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found

--- a/app/controllers/concerns/timeoutable.rb
+++ b/app/controllers/concerns/timeoutable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Timeoutable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_timeout_in
+  end
+
+  private
+
+  def set_timeout_in
+    @timeout_in = current_user.timeout_in.in_milliseconds if user_signed_in?
+  end
+end

--- a/app/javascript/controllers/timeoutable_controller.js
+++ b/app/javascript/controllers/timeoutable_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["alert"]
+  static values = { timeoutIn: Number }
+
+  connect() {
+    if (this.timeoutInValue) {
+      this.startTimeoutTimer()
+    }
+  }
+
+  disconnect() {
+    this.stopTimeoutTimer()
+  }
+
+  // private
+
+  alertTimeout() {
+    this.alertTarget.classList.remove("d-none")
+    this.stopTimeoutTimer()
+  }
+
+  startTimeoutTimer() {
+    this.timer = setInterval(() => {
+      this.alertTimeout()
+    }, this.timeoutInValue - 300000) // Alert user when only 5 min of the session time is remaining
+  }
+
+  stopTimeoutTimer() {
+    if (this.timer) {
+      clearInterval(this.timer)
+    }
+  }
+}

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -4,7 +4,7 @@
 class Administrator < ApplicationRecord
   devise :database_authenticatable,
     :recoverable, :trackable, :validatable, :confirmable, :lockable,
-    :timeoutable, timeout_in: 60.minutes
+    :timeoutable
 
   include DeactivationFlow
   before_save :remove_mark_for_deactivation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :trackable, :validatable,
-    :confirmable, :lockable,
+    :confirmable, :lockable, :timeoutable,
     :omniauthable, omniauth_providers: User.omniauth_providers
   include Suspendable
   include DeletionFlow

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,9 +12,10 @@
     = favicon_pack_tag 'favicon-16x16.png', rel: 'icon', type: 'image/png', sizes: '16x16'
     = favicon_pack_tag 'favicon-32x32.png', rel: 'icon', type: 'image/png', sizes: '32x32'
     = javascript_pack_tag 'bundle'
-  %body
+  %body{data: { controller: "timeoutable", timeoutable_timeout_in_value: @timeout_in }}
     #__SVG_SPRITE_NODE__{'data-turbo-permanent': true}
     = render partial: '/shared/header'
+    = render partial: '/shared/timeout'
     %button.scroll.rf-btn{data: { controller: "scroll", action: "scroll#top"}} ▲
     - if flash[:notice] || flash[:alert] || flash[:error] || flash[:success]
       .rf-container

--- a/app/views/shared/_timeout.html.haml
+++ b/app/views/shared/_timeout.html.haml
@@ -1,0 +1,5 @@
+.rf-container.d-none{data: {timeoutable_target: "alert" }}
+  .rf-grid-row
+    .rf-col-12.mx-md-auto
+      .fixed-bottom.alert.alert-info
+        Sans action de votre part dans les prochaines minutes, votre session expirera et vous serez déconnecté de la plateforme.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -175,7 +175,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 60.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
Closes #1067 

On rend la session utilisateur timeoutable (comme pour l'admin), avec une durée de session de 1h.

5 minutes avant la fin de la session, on affiche une alerte : 

![image](https://user-images.githubusercontent.com/1193334/177137191-aa4afd97-9333-4bfa-9e78-8a6d4922d032.png)
