### PR TITLE
feat: validate a domain

### DIFF
--- a/app/controllers/domain_validations_controller.rb
+++ b/app/controllers/domain_validations_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DomainValidationsController < ApplicationController
+  respond_to :txt
+
+  def show
+    @env_var_name = "DOMAIN_VALIDATION_#{params[:file_name].upcase}"
+  end
+end

--- a/app/controllers/domain_validations_controller.rb
+++ b/app/controllers/domain_validations_controller.rb
@@ -4,6 +4,6 @@ class DomainValidationsController < ApplicationController
   respond_to :txt
 
   def show
-    @env_value = ENV["DOMAIN_VALIDATION_#{params[:file_name].upcase}]"
+    @env_value = ENV["DOMAIN_VALIDATION_#{params[:file_name].upcase}"]
   end
 end

--- a/app/controllers/domain_validations_controller.rb
+++ b/app/controllers/domain_validations_controller.rb
@@ -4,6 +4,6 @@ class DomainValidationsController < ApplicationController
   respond_to :txt
 
   def show
-    @env_var_name = "DOMAIN_VALIDATION_#{params[:file_name].upcase}"
+    @env_value = ENV["DOMAIN_VALIDATION_#{params[:file_name].upcase}]"
   end
 end

--- a/app/views/domain_validations/show.text.erb
+++ b/app/views/domain_validations/show.text.erb
@@ -1,0 +1,1 @@
+<%= ENV[@env_var_name] %>

--- a/app/views/domain_validations/show.text.erb
+++ b/app/views/domain_validations/show.text.erb
@@ -1,1 +1,1 @@
-<%= ENV[@env_var_name] %>
+<%= @env_value %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
   get "/politique-confidentialite", to: redirect("/pages/politique-de-confidentialite")
   get "/suivi", to: redirect("/pages/suivi-d-audience-et-vie-privee")
 
+  # Domains check
+  get "/.well-known/pki-validation/:file_name" => "domain_validations#show", :as => :domain_validations
+
   as :administrator do
     patch "/admin/confirmation" => "administrators/confirmations#update", :as => :update_administrator_confirmation
   end

--- a/spec/requests/domain_validations_spec.rb
+++ b/spec/requests/domain_validations_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DomainValidationsController, type: :request do
+  describe "GET /.well-known/pki-validation/:file_name" do
+    context "when there is a matching environment variable prefixed with DOMAIN_VALIDATION_" do
+      let(:file_name) { "a_file" }
+      let(:value) { "hello world" }
+
+      before { ENV["DOMAIN_VALIDATION_#{file_name.upcase}"] = value }
+
+      it "returns the environment variable value as plain text" do
+        get domain_validations_path(file_name, format: :txt)
+        expect(response.headers["Content-Type"]).to eq("text/plain; charset=utf-8")
+        expect(response.body).to eq(value)
+      end
+    end
+
+    context "when there is no matching environment variable prefixed with DOMAIN_VALIDATION_" do
+      it "returns an empty content as plain text" do
+        get domain_validations_path("unknown", format: :txt)
+        expect(response.headers["Content-Type"]).to eq("text/plain; charset=utf-8")
+        expect(response.body).to eq("")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Afin de valider un nom de domaine, on retourne sous forme de plain text le contenu d'une variable d'environnement préfixée par `DOMAIN_VALIDATION_`.

# Production

- [ ] Définir la variable d'environnement telle que demandée par le client