### PR TITLE
optim: avoid requesting twice the DB

### DIFF
--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,4 +1,5 @@
 - @page_title = t('.title')
+- users_count = @users_filtered.count
 .card
   .card-header
     .h4.text-primary.d-md-flex.align-items-center
@@ -7,7 +8,7 @@
     = form_tag(multi_select_admin_users_url, data: {controller: "selectall"}) do
       .d-flex.align-items-end
         .h5.text-primary.mr-auto
-          = t('.users_filtered', count: @users_filtered.count)
+          = t('.users_filtered', count: users_count)
         - klasses = %w[btn btn-link mb-0]
         = sort_link(@q, :created_at, {}, {class: klasses}) do
           Date de création
@@ -21,7 +22,7 @@
 
       .row{data: { controller: 'subcheckbox'}}
         .col-12
-          - if @users_filtered.any?
+          - unless users_count.zero?
             .row
               .col-auto.align-self-center.text-center
                 %label


### PR DESCRIPTION
Should fix this double request when searching (full text) for candidates:
![image](https://user-images.githubusercontent.com/1193334/177290814-730f47bb-4273-4142-b29b-eb80cf3e807f.png)
