### PR TITLE
feat: job offer's archiving reason

### DIFF
--- a/app/controllers/admin/archives_controller.rb
+++ b/app/controllers/admin/archives_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Admin::ArchivesController < Admin::BaseController
+  skip_load_and_authorize_resource
+  load_and_authorize_resource :job_offer
+
+  def new
+  end
+
+  def create
+    @job_offer.attributes = job_offer_params
+    @job_offer.archive!
+    @notification = t(".success")
+  end
+
+  private
+
+  def job_offer_params
+    params.require(:job_offer).permit(:archiving_reason_id)
+  end
+end

--- a/app/controllers/admin/settings/archiving_reasons_controller.rb
+++ b/app/controllers/admin/settings/archiving_reasons_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Admin::Settings::ArchivingReasonsController < Admin::Settings::InheritedResourcesController
+end

--- a/app/javascript/packs/admin-bundle.js
+++ b/app/javascript/packs/admin-bundle.js
@@ -37,6 +37,7 @@ importAll(require.context('images/', true, /\.(ico|png|jpe?g|svg|gif)$/))
 importAll(require.context('icons/', true, /\.svg$/))
 
 import BSN from 'bootstrap.native/dist/bootstrap-native.js'
+window.BSN = BSN
 import Snackbar from 'node-snackbar'
 window.Snackbar = Snackbar
 import offCanvas from 'js/off-canvas'

--- a/app/models/archiving_reason.rb
+++ b/app/models/archiving_reason.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ArchivingReason < ApplicationRecord
+  acts_as_list
+
+  default_scope -> { order(position: :asc) }
+
+  validates :name, presence: true
+end
+
+# == Schema Information
+#
+# Table name: archiving_reasons
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_archiving_reasons_on_position  (position)
+#

--- a/app/models/archiving_reason.rb
+++ b/app/models/archiving_reason.rb
@@ -3,6 +3,8 @@
 class ArchivingReason < ApplicationRecord
   acts_as_list
 
+  has_many :job_offers, dependent: :nullify, inverse_of: :archiving_reason
+
   default_scope -> { order(position: :asc) }
 
   validates :name, presence: true

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -121,7 +121,7 @@ class JobOffer < ApplicationRecord
 
   ## States and events
   aasm column: :state, enum: true do
-    state :draft, initial: true, before_enter: :set_timestamp
+    state :draft, initial: true, before_enter: [:set_timestamp, :clean_archiving_reason]
     state :published, before_enter: :set_timestamp
     state :suspended, before_enter: :set_timestamp
     state :archived, before_enter: :set_timestamp
@@ -187,6 +187,10 @@ class JobOffer < ApplicationRecord
     return unless respond_to?("#{to}_at=")
 
     send("#{to}_at=", Time.zone.now)
+  end
+
+  def clean_archiving_reason
+    self.archiving_reason = nil
   end
 
   def self.new_from_scratch(reference_administrator)

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -41,6 +41,7 @@ class JobOffer < ApplicationRecord
   end
   belongs_to :contract_duration, optional: true
   belongs_to :bop, optional: true
+  belongs_to :archiving_reason, optional: true
 
   has_many :benefit_job_offers, dependent: :destroy
   has_many :benefits, through: :benefit_job_offers
@@ -344,6 +345,7 @@ end
 #  to_be_met_job_applications_count                 :integer          default(0), not null
 #  created_at                                       :datetime         not null
 #  updated_at                                       :datetime         not null
+#  archiving_reason_id                              :uuid
 #  bop_id                                           :uuid
 #  category_id                                      :uuid
 #  contract_duration_id                             :uuid
@@ -359,6 +361,7 @@ end
 #
 # Indexes
 #
+#  index_job_offers_on_archiving_reason_id       (archiving_reason_id)
 #  index_job_offers_on_bop_id                    (bop_id)
 #  index_job_offers_on_category_id               (category_id)
 #  index_job_offers_on_contract_duration_id      (contract_duration_id)
@@ -381,6 +384,7 @@ end
 #  fk_rails_2e21ee1517  (study_level_id => study_levels.id)
 #  fk_rails_39bc76a4ec  (contract_type_id => contract_types.id)
 #  fk_rails_3afb853ff8  (bop_id => bops.id)
+#  fk_rails_4cbd429856  (archiving_reason_id => archiving_reasons.id)
 #  fk_rails_578c30296c  (category_id => categories.id)
 #  fk_rails_5aaea6c8db  (employer_id => employers.id)
 #  fk_rails_6cf1ead2e5  (owner_id => administrators.id)

--- a/app/views/admin/archives/_form.html.haml
+++ b/app/views/admin/archives/_form.html.haml
@@ -1,0 +1,14 @@
+.card 
+  .card-header
+    = t('.title')
+  .card-body
+    = simple_form_for(@job_offer, url: [:admin, @job_offer, :archives], method: :post, remote: true) do |f|
+      = f.error_notification
+      = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
+      - if @job_offer.errors.any?
+        .alert.alert-danger.pt-0
+          %ul.mb-0
+            - @job_offer.errors.full_messages.each do |msg|
+              %li= msg
+      = f.input :archiving_reason_id, collection: ArchivingReason.all, label: false, prompt: :translate, include_blank: :translate
+      = f.submit t('.submit'), class: 'btn btn-primary btn-raised'

--- a/app/views/admin/archives/create.js.erb
+++ b/app/views/admin/archives/create.js.erb
@@ -1,0 +1,10 @@
+<% if @job_offer.errors.any? %>
+  document.querySelector('#modal').querySelector('.modal-body').innerHTML = '<%= j render(partial: 'form') %>'
+<% else %>
+  var jobOffer = document.getElementById('<%= dom_id(@job_offer) %>')
+  var html = '<%= j render(partial: '/admin/job_offers/job_offer', locals: { job_offer: @job_offer }) %>'
+  var frag = document.createRange().createContextualFragment(html)
+  jobOffer.replaceWith(frag)
+  Snackbar.show({showAction: false, text: '<%= @notification %>'})
+  new window.BSN.Modal('#modal').hide()
+<% end %>

--- a/app/views/admin/archives/new.js.erb
+++ b/app/views/admin/archives/new.js.erb
@@ -1,0 +1,2 @@
+document.querySelector('#modal').querySelector('.modal-body').innerHTML = '<%= j render(partial: 'form') %>'
+new window.BSN.Modal('#modal').show()

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -35,6 +35,8 @@
             = "#{job_offer.aasm.human_state}"
           - if job_offer.state_date
             = I18n.l(job_offer.state_date.to_date)
+          - if job_offer.archiving_reason.present?
+            = job_offer.archiving_reason.name
         %ul.list-inline.mb-0.actions.mt-2.mt-md-0
           %li.list-inline-item.d-none
             = link_to '#' do

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -58,7 +58,7 @@
               .dropdown
                 = button_tag type: 'button', data: { toggle: "dropdown" }, aria: { haspopup: true, expanded: false }, class: "btn btn-link btn-sm mb-0 px-0 py-0" do
                   = fa_icon 'dots-horizontal'
-                .dropdown-menu{"aria-labelledby" => "dropdownMenuLink"}
+                .dropdown-menu.dropdown-menu-right{"aria-labelledby" => "dropdownMenuLink"}
                   - job_offer.possible_events.each do |event_name|
                     - unless event_name.starts_with?(job_offer.state)
                       = link_to [event_name.to_sym, :admin, job_offer], method: :patch, remote: true, class: "dropdown-item" do

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -62,7 +62,11 @@
                   = fa_icon 'dots-horizontal'
                 .dropdown-menu.dropdown-menu-right{"aria-labelledby" => "dropdownMenuLink"}
                   - job_offer.possible_events.each do |event_name|
-                    - unless event_name.starts_with?(job_offer.state)
+                    - if event_name == "archive"
+                      = link_to [:new, :admin, job_offer, :archive], class: "dropdown-item", remote: true do
+                        = fa_icon('arrow-right', class: 'mr-1')
+                        = t("buttons.#{ event_name }")
+                    - elsif !event_name.starts_with?(job_offer.state)
                       = link_to [event_name.to_sym, :admin, job_offer], method: :patch, remote: true, class: "dropdown-item" do
                         = fa_icon('arrow-right', class: 'mr-1')
                         = t("buttons.#{ event_name }")

--- a/app/views/admin/settings/shared/_navbar.html.haml
+++ b/app/views/admin/settings/shared/_navbar.html.haml
@@ -73,7 +73,7 @@
       = link_to [:admin, :settings, entry.to_sym], class: klasses do
         = t(".#{ entry }")
   - entries = JobOffer::SETTINGS.map{|x| x.to_s.pluralize.to_sym}
-  - entries += %i[benefits bops salary_ranges rejection_reasons contract_durations foreign_languages foreign_language_levels job_offer_terms]
+  - entries += %i[archiving_reasons benefits bops salary_ranges rejection_reasons contract_durations foreign_languages foreign_language_levels job_offer_terms]
   - if entries.any?{ |entry| can?(:manage, entry.to_s.singularize.classify.constantize) }
     .list-group-item.menu
       = t(".writing_job_offers")

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -45,3 +45,4 @@
               .alert.alert-success= flash[:success]
             = yield
       = javascript_pack_tag 'devise-bundle'
+    = render partial: '/shared/modal'

--- a/app/views/shared/_modal.html.haml
+++ b/app/views/shared/_modal.html.haml
@@ -1,0 +1,4 @@
+.modal.fade#modal{tabindex: -1, role: :dialog, aria: {labelledby: :modal, hidden: true}}
+  .modal-dialog
+    .modal-content
+      .modal-body.p-0

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -550,6 +550,7 @@ fr:
           frequently_asked_questions: "FAQ"
           job_offer_terms: "Conditions d'accès à la création d'offres"
           user_menu_links: "Onglet espace candidat"
+          archiving_reasons: "Motifs d'archivage"
       base:
         index:
           title: "Paramètres"
@@ -821,6 +822,20 @@ fr:
       rejection_reasons:
         index:
           title: "Motifs de rejet d'une candidature"
+          add: "Ajouter"
+          card_title:
+            zero: 'Aucun motif pour le moment'
+            one: '1 motif'
+            other: '%{count} motifs'
+        new:
+          title: "Ajouter un motif"
+        create:
+          success: "Motif ajouté !"
+        destroy:
+          success: "Motif supprimé !"
+      archiving_reasons:
+        index:
+          title: "Motifs d'archivage d'une offre'"
           add: "Ajouter"
           card_title:
             zero: 'Aucun motif pour le moment'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -433,6 +433,8 @@ fr:
         success: "Annonce mise à jour !"
       archive:
         success: "Annonce archivée !"
+      unarchive:
+        success: "Annonce désarchivée !"
       update_and_archive:
         success: "Annonce mise à jour et archivée !"
       suspend:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -448,6 +448,12 @@ fr:
       readings:
         create:
           success: "Toutes les notifications ont été marquées comme lues !"
+    archives:
+      form:
+        submit: "Archiver"
+        title: "Archiver cette annonce ?"
+      create:
+        success: "Annonce archivée !"
     emails:
       create:
         success: "Courriel envoyé !"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -206,16 +206,19 @@ fr:
           email: "Courriel Grand Employeur"
         title: "Fonction"
       message:
-        body: 'Ce commentaire ne sera visible que par vous et les
-autres membres de votre équipe.'
+        body: 'Ce commentaire ne sera visible que par vous et les autres membres de votre équipe.'
     prompts:
       administrator:
         role: 'Sélectionner un rôle'
       job_application:
         rejection_reason_id: 'Choisissez un motif de refus'
+      job_offer:
+        archiving_reason_id: "Choisissez un motif d'archivage"
     include_blanks:
       administrator:
         role: 'Aucun rôle'
+      job_offer:
+        archiving_reason_id: 'Aucune raison'
     hints:
       defaults:
         current_position: "Si aucun poste occupé actuellement, saisir \"sans emploi\"."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
           get :emails
         end
       end
+      resources :archives, only: [:new, :create]
       resources :multiple_recipients_emails, only: %i[new create]
       resources :recipients, only: %i[index create]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,7 +179,7 @@ Rails.application.routes.draw do
       resources :salary_ranges
       resources :job_application_file_types
       other_settings = %i[
-        benefit bops email_template job_application_file_types rejection_reasons
+        archiving_reasons benefit bops email_template job_application_file_types rejection_reasons
         contract_duration foreign_languages foreign_language_levels job_offer_terms
         user_menu_links
       ]

--- a/db/migrate/20220706084116_create_archiving_reasons.rb
+++ b/db/migrate/20220706084116_create_archiving_reasons.rb
@@ -1,0 +1,12 @@
+class CreateArchivingReasons < ActiveRecord::Migration[6.1]
+  def change
+    create_table :archiving_reasons, id: :uuid do |t|
+      t.string :name
+      t.integer :position
+
+      t.timestamps
+    end
+
+    add_index :archiving_reasons, :position
+  end
+end

--- a/db/migrate/20220706090806_add_archiving_reason_to_job_offers.rb
+++ b/db/migrate/20220706090806_add_archiving_reason_to_job_offers.rb
@@ -1,0 +1,5 @@
+class AddArchivingReasonToJobOffers < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :job_offers, :archiving_reason, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_01_133806) do
+ActiveRecord::Schema.define(version: 2022_07_06_084116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -100,6 +100,14 @@ ActiveRecord::Schema.define(version: 2022_07_01_133806) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_age_ranges_on_name"
     t.index ["position"], name: "index_age_ranges_on_position"
+  end
+
+  create_table "archiving_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.integer "position"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["position"], name: "index_archiving_reasons_on_position"
   end
 
   create_table "audits", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_084116) do
+ActiveRecord::Schema.define(version: 2022_07_06_090806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -445,6 +445,8 @@ ActiveRecord::Schema.define(version: 2022_07_06_084116) do
     t.date "pep_date"
     t.string "bne_value"
     t.date "bne_date"
+    t.uuid "archiving_reason_id"
+    t.index ["archiving_reason_id"], name: "index_job_offers_on_archiving_reason_id"
     t.index ["bop_id"], name: "index_job_offers_on_bop_id"
     t.index ["category_id"], name: "index_job_offers_on_category_id"
     t.index ["contract_duration_id"], name: "index_job_offers_on_contract_duration_id"
@@ -768,6 +770,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_084116) do
   add_foreign_key "job_offer_actors", "administrators"
   add_foreign_key "job_offer_actors", "job_offers"
   add_foreign_key "job_offers", "administrators", column: "owner_id"
+  add_foreign_key "job_offers", "archiving_reasons"
   add_foreign_key "job_offers", "bops"
   add_foreign_key "job_offers", "categories"
   add_foreign_key "job_offers", "contract_types"

--- a/spec/factories/archiving_reasons.rb
+++ b/spec/factories/archiving_reasons.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :archiving_reason do
+    name { "MyString" }
+    position { 1 }
+  end
+end
+
+# == Schema Information
+#
+# Table name: archiving_reasons
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_archiving_reasons_on_position  (position)
+#

--- a/spec/factories/job_offers.rb
+++ b/spec/factories/job_offers.rb
@@ -27,6 +27,12 @@ FactoryBot.define do
       published_at { 40.days.before }
       state { :published }
     end
+
+    factory :archived_job_offer do
+      archived_at { 40.days.before }
+      state { :archived }
+      archiving_reason
+    end
   end
 
   trait :with_job_applications do

--- a/spec/factories/job_offers.rb
+++ b/spec/factories/job_offers.rb
@@ -89,6 +89,7 @@ end
 #  to_be_met_job_applications_count                 :integer          default(0), not null
 #  created_at                                       :datetime         not null
 #  updated_at                                       :datetime         not null
+#  archiving_reason_id                              :uuid
 #  bop_id                                           :uuid
 #  category_id                                      :uuid
 #  contract_duration_id                             :uuid
@@ -104,6 +105,7 @@ end
 #
 # Indexes
 #
+#  index_job_offers_on_archiving_reason_id       (archiving_reason_id)
 #  index_job_offers_on_bop_id                    (bop_id)
 #  index_job_offers_on_category_id               (category_id)
 #  index_job_offers_on_contract_duration_id      (contract_duration_id)
@@ -126,6 +128,7 @@ end
 #  fk_rails_2e21ee1517  (study_level_id => study_levels.id)
 #  fk_rails_39bc76a4ec  (contract_type_id => contract_types.id)
 #  fk_rails_3afb853ff8  (bop_id => bops.id)
+#  fk_rails_4cbd429856  (archiving_reason_id => archiving_reasons.id)
 #  fk_rails_578c30296c  (category_id => categories.id)
 #  fk_rails_5aaea6c8db  (employer_id => employers.id)
 #  fk_rails_6cf1ead2e5  (owner_id => administrators.id)

--- a/spec/models/archiving_reason_spec.rb
+++ b/spec/models/archiving_reason_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ArchivingReason, type: :model do
+  it { should validate_presence_of(:name) }
+end
+
+# == Schema Information
+#
+# Table name: archiving_reasons
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_archiving_reasons_on_position  (position)
+#

--- a/spec/models/archiving_reason_spec.rb
+++ b/spec/models/archiving_reason_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ArchivingReason, type: :model do
-  it { should validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:name) }
 end
 
 # == Schema Information

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe JobOffer, type: :model do
+  it { is_expected.to belong_to(:archiving_reason).optional(true) }
+
   let(:job_offer) { create(:job_offer) }
   let(:employer) { create(:employer) }
   let(:organization) { job_offer.organization }
@@ -296,6 +298,7 @@ end
 #  to_be_met_job_applications_count                 :integer          default(0), not null
 #  created_at                                       :datetime         not null
 #  updated_at                                       :datetime         not null
+#  archiving_reason_id                              :uuid
 #  bop_id                                           :uuid
 #  category_id                                      :uuid
 #  contract_duration_id                             :uuid
@@ -311,6 +314,7 @@ end
 #
 # Indexes
 #
+#  index_job_offers_on_archiving_reason_id       (archiving_reason_id)
 #  index_job_offers_on_bop_id                    (bop_id)
 #  index_job_offers_on_category_id               (category_id)
 #  index_job_offers_on_contract_duration_id      (contract_duration_id)
@@ -333,6 +337,7 @@ end
 #  fk_rails_2e21ee1517  (study_level_id => study_levels.id)
 #  fk_rails_39bc76a4ec  (contract_type_id => contract_types.id)
 #  fk_rails_3afb853ff8  (bop_id => bops.id)
+#  fk_rails_4cbd429856  (archiving_reason_id => archiving_reasons.id)
 #  fk_rails_578c30296c  (category_id => categories.id)
 #  fk_rails_5aaea6c8db  (employer_id => employers.id)
 #  fk_rails_6cf1ead2e5  (owner_id => administrators.id)

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe JobOffer, type: :model do
-  it { is_expected.to belong_to(:archiving_reason).optional(true) }
-
-  let(:job_offer) { create(:job_offer) }
-  let(:employer) { create(:employer) }
   let(:organization) { job_offer.organization }
+  let(:employer) { create(:employer) }
+  let(:job_offer) { create(:job_offer) }
+
+  it { is_expected.to belong_to(:archiving_reason).optional(true) }
 
   %i[employer grand_employer supervisor_employer brh].each do |role|
     it { is_expected.to have_many("job_offer_#{role}_actors".to_sym).inverse_of(:job_offer) }

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -243,6 +243,13 @@ RSpec.describe JobOffer, type: :model do
       end
     end
   end
+
+  describe "unarchiving" do
+    it "removes the archiving reason when it exists" do
+      job_offer = create(:archived_job_offer)
+      expect { job_offer.unarchive! }.to change { job_offer.reload.archiving_reason }.to(nil)
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/requests/admin/archives_spec.rb
+++ b/spec/requests/admin/archives_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::ArchivesController, type: :request do
+  let(:job_offer) { create(:job_offer) }
+
+  before { sign_in create(:administrator) }
+
+  describe "GET /new" do
+    it "shows the archive modal" do
+      get new_admin_job_offer_archive_path(job_offer), xhr: true
+      expect(response).to be_successful
+      expect(response.body).to include(I18n.t(".admin.archives.form.title"))
+    end
+  end
+
+  describe "POST /create" do
+    context "when an archiving reason is provided" do
+      let(:archiving_reason) { create(:archiving_reason) }
+      let(:params) {
+        {
+          job_offer: {
+            archiving_reason_id: archiving_reason.id
+          }
+        }
+      }
+
+      it "archives the job offer" do
+        expect {
+          post admin_job_offer_archives_path(job_offer), params: params, xhr: true
+        }.to change { job_offer.reload.archived? }.to(true)
+      end
+
+      it "stores the archiving reason" do
+        expect {
+          post admin_job_offer_archives_path(job_offer), params: params, xhr: true
+        }.to change { job_offer.reload.archiving_reason }.to(archiving_reason)
+      end
+    end
+
+    context "when the archiving reason is not provided" do
+      let(:params) {
+        {
+          job_offer: {
+            archiving_reason_id: ""
+          }
+        }
+      }
+
+      it "archives the job offer" do
+        expect {
+          post admin_job_offer_archives_path(job_offer), params: params, xhr: true
+        }.to change { job_offer.reload.archived? }.to(true)
+      end
+
+      it "doesn't store the archiving reason" do
+        expect {
+          post admin_job_offer_archives_path(job_offer), params: params, xhr: true
+        }.not_to change { job_offer.reload.archiving_reason }
+      end
+    end
+  end
+end

--- a/spec/requests/admin/settings/archiving_reasons_spec.rb
+++ b/spec/requests/admin/settings/archiving_reasons_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Settings::ArchivingReasonsController, type: :request do
+  describe "GET /admin/parametres/archiving_reasons" do
+    it "lists the archiving reasons" do
+      archiving_reason = create(:archiving_reason)
+      sign_in create(:administrator)
+
+      get admin_settings_archiving_reasons_path
+      expect(response.body).to include(archiving_reason.name)
+    end
+  end
+end


### PR DESCRIPTION
closes #444 

On ajoute un motif lors de l'archivage d'une annonce.

Pour cela, on commence par ajouter les motifs d'archivage dans les paramètres :
![image](https://user-images.githubusercontent.com/1193334/179486987-0fa7abc7-2a23-44bd-97da-14f44c730819.png)

Puis, au moment d'archiver l'annonce, une modale permet de choisir le motif : 
![image](https://user-images.githubusercontent.com/1193334/179487208-d4dbee0a-9e53-4cdf-bcab-a067965d35fc.png)

La raison est alors visible dans le cartouche de l'offre : 
![image](https://user-images.githubusercontent.com/1193334/179487295-3e8de5bb-7870-490d-bba2-9552bc43e361.png)
