### PR TITLE
feat: improve filters UI

### DIFF
--- a/app/views/admin/stats/job_applications/_search.html.haml
+++ b/app/views/admin/stats/job_applications/_search.html.haml
@@ -9,18 +9,18 @@
               = fa_icon('magnify')
           = text_field_tag :s, params[:s]
         .row.mt-5
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_employer'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_category'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_contract_type'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_bop'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_experience_level'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_study_level'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_department'
         = submit_tag 'Rechercher', name: nil, class: 'd-none'

--- a/app/views/admin/users/_search.html.haml
+++ b/app/views/admin/users/_search.html.haml
@@ -9,23 +9,23 @@
               = fa_icon('magnify')
           = text_field_tag :s, params[:s], placeholder: 'Mot-clés'
         .row.mt-2
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_state'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_study_level'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_experience_level'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_availability_range'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_has_corporate_experience'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_category'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_department'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_spontaneous'
-          .col-12.col-sm-3
+          .col-12.col-md-6.col-lg-4
             = render partial: 'filter_concerned'
         .d-flex.flex-row-reverse.align-items-center
           = submit_tag t('buttons.search'), name: nil, class: 'btn btn-primary btn-raised btn-small'

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -34,7 +34,7 @@ fr:
         age_range: "Tranche d'âge"
         availability_range: "Disponibilité"
         body: "Corps du courriel"
-        department: "Souhait(s) géographique(s) (département)"
+        department: "Souhait(s) géographique(s)"
         city: "Ville"
         country: "Pays"
         current_position: "Poste actuel"


### PR DESCRIPTION
closes #1087

Sur les deux écrans concernés (vivier et statistiques), on établit la largeur et la position des filtres en fonction de la largeur de l'écran. On réduit également un peu la longueur des wordings, pour que ça rentre mieux.

# Vivier

![image](https://user-images.githubusercontent.com/1193334/179512659-0e8d2c62-7c16-4371-9a30-a55eec1d2337.png)

![image](https://user-images.githubusercontent.com/1193334/179512709-2f4dbc27-6863-4f9a-845d-49f3e4f650c1.png)

![image](https://user-images.githubusercontent.com/1193334/179512768-b9238aa5-a287-44ca-a565-a2fe0859da23.png)

# Statistiques

![image](https://user-images.githubusercontent.com/1193334/179512843-1ae1af0a-48fb-4b03-91f7-90189fd6d648.png)

![image](https://user-images.githubusercontent.com/1193334/179512890-511a2fdf-edac-4a8e-9fb9-f19488212a7d.png)

![image](https://user-images.githubusercontent.com/1193334/179512952-f2555e29-aa3a-4d4a-9673-585ac27df5ec.png)


