### PR TITLE
:zap: stats: cache the job applications stats for 24h

### DIFF
--- a/app/controllers/admin/stats/job_applications_controller.rb
+++ b/app/controllers/admin/stats/job_applications_controller.rb
@@ -103,7 +103,7 @@ class Admin::Stats::JobApplicationsController < Admin::Stats::BaseController
   def date_end
     @date_end ||= begin
       res = Date.parse(permitted_params[:end]) if permitted_params[:end].present?
-      res ||= Time.zone.today
+      res ||= 1.day.ago.to_date
       res
     end
   end

--- a/app/controllers/admin/stats/job_applications_controller.rb
+++ b/app/controllers/admin/stats/job_applications_controller.rb
@@ -59,37 +59,7 @@ class Admin::Stats::JobApplicationsController < Admin::Stats::BaseController
   end
 
   def build_state_duration
-    @state_duration ||= cached_state_duration
-  end
-
-  STATE_DURATION = [
-    [:initial, :rejected],
-    [:initial, :phone_meeting],
-    [:phone_meeting, :phone_meeting_rejected],
-    [:phone_meeting, :to_be_met],
-    [:to_be_met, :after_meeting_rejected],
-    [:to_be_met, :accepted],
-    [:accepted, :contract_drafting],
-    [:contract_drafting, :contract_feedback_waiting],
-    [:contract_feedback_waiting, :contract_received],
-    [:contract_received, :affected]
-  ]
-  def cached_state_duration
-    Rails.cache.fetch(root_rel.to_sql, expires_in: 24.hours) do
-      STATE_DURATION.map { |from, to|
-        from_state = JobApplication.states[from].to_s
-        to_state = JobApplication.states[to].to_s
-        days = root_rel
-          .joins('INNER JOIN "audits" AS audits_start ON "audits_start"."auditable_type" = \'JobApplication\' AND "audits_start"."auditable_id" = "job_applications"."id"')
-          .joins('INNER JOIN "audits" AS audits_end ON "audits_start"."auditable_type" = \'JobApplication\'
-            AND "audits_end"."auditable_id" = "job_applications"."id"')
-          .where("audits_start.audited_changes->?->-1 @> ?", :state, from_state)
-          .where("audits_end.audited_changes->?->-1 @> ?", :state, to_state)
-          .pluck(Arel.sql("DATE_PART('day', audits_end.created_at - audits_start.created_at)"))
-        average = days.present? ? (days.reduce(:+) / days.size.to_f).round : "-"
-        [from, to, average]
-      }
-    end
+    @state_duration = JobApplication.cache_state_durations_map(root_rel)
   end
 
   def date_start

--- a/app/controllers/admin/stats/job_offers_controller.rb
+++ b/app/controllers/admin/stats/job_offers_controller.rb
@@ -63,7 +63,7 @@ class Admin::Stats::JobOffersController < Admin::Stats::BaseController
   def date_start
     @date_start ||= begin
       res = Date.parse(permitted_params[:start]) if permitted_params[:start].present?
-      res ||= 30.days.ago.beginning_of_day
+      res ||= 30.days.ago.to_date
       res
     end
   end
@@ -71,7 +71,7 @@ class Admin::Stats::JobOffersController < Admin::Stats::BaseController
   def date_end
     @date_end ||= begin
       res = Date.parse(permitted_params[:end]) if permitted_params[:end].present?
-      res ||= Time.current
+      res ||= 1.day.ago.to_date
       res
     end
   end

--- a/app/jobs/warm_up_job_applications_stats_cache_job.rb
+++ b/app/jobs/warm_up_job_applications_stats_cache_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class WarmUpJobApplicationsStatsCacheJob < ApplicationJob
+  queue_as :default
+
+  def perform(start_date:, end_date:)
+    JobApplication.cache_state_durations_map(
+      JobApplication
+        .where(created_at: start_date..end_date)
+        .ransack(start: start_date, end: end_date)
+        .result(distinct: true)
+        .unscope(:order)
+    )
+  end
+end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -102,6 +102,37 @@ class JobApplication < ApplicationRecord
     ]
   end
 
+  STATE_DURATION = [
+    [:initial, :rejected],
+    [:initial, :phone_meeting],
+    [:phone_meeting, :phone_meeting_rejected],
+    [:phone_meeting, :to_be_met],
+    [:to_be_met, :after_meeting_rejected],
+    [:to_be_met, :accepted],
+    [:accepted, :contract_drafting],
+    [:contract_drafting, :contract_feedback_waiting],
+    [:contract_feedback_waiting, :contract_received],
+    [:contract_received, :affected]
+  ]
+
+  def self.cache_state_durations_map(scope)
+    Rails.cache.fetch(scope.to_sql, expires_in: 24.hours) do
+      STATE_DURATION.map { |from, to|
+        from_state = states[from].to_s
+        to_state = states[to].to_s
+        days = scope
+          .joins('INNER JOIN "audits" AS audits_start ON "audits_start"."auditable_type" = \'JobApplication\' AND "audits_start"."auditable_id" = "job_applications"."id"')
+          .joins('INNER JOIN "audits" AS audits_end ON "audits_start"."auditable_type" = \'JobApplication\'
+            AND "audits_end"."auditable_id" = "job_applications"."id"')
+          .where("audits_start.audited_changes->?->-1 @> ?", :state, from_state)
+          .where("audits_end.audited_changes->?->-1 @> ?", :state, to_state)
+          .pluck(Arel.sql("DATE_PART('day', audits_end.created_at - audits_start.created_at)"))
+        average = days.present? ? (days.reduce(:+) / days.size.to_f).round : "-"
+        [from, to, average]
+      }
+    end
+  end
+
   def end_user_state_number
     self.class.end_user_states_regrouping.index { |x| x.include?(state.to_sym) } + 1
   end

--- a/clock.rb
+++ b/clock.rb
@@ -43,4 +43,19 @@ module Clockwork
       DailySummary.new(day: 1.day.ago).prepare_and_send
     end
   end
+
+  every 30.minutes, "warm_up_job_applications_stats_cache" do
+    [
+      [1.month.ago.to_date, 1.day.ago.to_date],
+      [1.month.ago.to_date, Time.zone.today],
+      [1.month.ago.beginning_of_month.to_date, 1.day.ago.to_date],
+      [1.month.ago.beginning_of_month.to_date, Time.zone.today],
+      [1.month.ago.beginning_of_month.to_date, 1.month.ago.end_of_month.to_date],
+      [2.months.ago.beginning_of_month.to_date, 2.months.ago.end_of_month.to_date],
+      [2.months.ago.beginning_of_month.to_date, 1.day.ago.to_date],
+      [2.months.ago.beginning_of_month.to_date, Time.zone.today]
+    ].each do |start_date, end_date|
+      WarmUpJobApplicationsStatsCacheJob.perform_later(start_date: start_date, end_date: end_date)
+    end
+  end
 end

--- a/spec/jobs/warm_up_job_applications_stats_cache_job_spec.rb
+++ b/spec/jobs/warm_up_job_applications_stats_cache_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WarmUpJobApplicationsStatsCacheJob, type: :job do
+  it "warms up the job application state durations map cache" do
+    allow(JobApplication).to receive(:cache_state_durations_map)
+    start_date = 1.month.ago
+    end_date = 1.day.ago
+    scope = JobApplication
+      .where(created_at: start_date..end_date)
+      .ransack(start: start_date, end: end_date)
+      .result(distinct: true)
+      .unscope(:order)
+
+    described_class.new.perform(start_date: start_date, end_date: end_date)
+    expect(JobApplication).to have_received(:cache_state_durations_map).with(scope)
+  end
+end


### PR DESCRIPTION
Store the heaviest query in cache for to avoid 10+s total request duration, and warm up the cache periodically for the most common dates combinations.

closes #1325