### PR TITLE
:sparkles: auto save job offer and job application forms

### DIFF
--- a/app/inputs/trix_editor_custom_input.rb
+++ b/app/inputs/trix_editor_custom_input.rb
@@ -20,7 +20,7 @@ class TrixEditorCustomInput < Trix::SimpleForm::TrixEditorInput
       input: input_class,
       class: "trix-content",
       data: {
-        action: "trix-change->trix-editor#limit",
+        action: "trix-change->trix-editor#limit trix-change->form-save#saveFormData",
         "trix-editor-target": "editor"
       }
     }

--- a/app/javascript/controllers/autocomplete_city_controller.js
+++ b/app/javascript/controllers/autocomplete_city_controller.js
@@ -20,7 +20,6 @@ export default class extends Controller {
   }
 
   search() {
-    console.log("SEARHCX")
     this.queryTarget.querySelector("button").click()
   }
 

--- a/app/javascript/controllers/form_save_controller.js
+++ b/app/javascript/controllers/form_save_controller.js
@@ -1,0 +1,85 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["form", "ignored"]
+
+  connect() {
+    this.populateFormFromSavedData()
+  }
+
+  saveFormData() {
+    localStorage.setItem(this.getLocalStorageKey(), this.getStringifiedFormData())
+  }
+
+  clearFormData() {
+    if (localStorage.getItem(this.getLocalStorageKey()) == null) return
+
+    localStorage.removeItem(this.getLocalStorageKey())
+  }
+
+  // Private methods
+
+  populateFormFromSavedData() {
+    if (localStorage.getItem(this.getLocalStorageKey()) == null) return
+
+    const data = this.getSavedData()
+    const form = this.formTarget
+
+    Object.entries(data).forEach((entry) => {
+      let name = entry[0]
+      let value = entry[1]
+      let input = form.querySelector(`[name='${name}']`)
+
+      if (input) {
+        // Usual case
+        input.value = value
+
+        // If input is a trix editor, let's populate it as well
+        let trixEditor = input.parentElement.querySelector("trix-editor")
+        if (trixEditor != null) {
+          trixEditor.editor.insertHTML(value)
+        }
+      }
+    })
+  }
+
+  getSavedData() {
+    return JSON.parse(localStorage.getItem(this.getLocalStorageKey()))
+  }
+
+  getStringifiedFormData() {
+    return JSON.stringify(this.getFormData())
+  }
+
+  getFormData() {
+    const form = new FormData(this.formTarget)
+
+    Array.from(this.formTarget.elements).forEach((input) => {
+      if (this.isIgnored(input)) {
+        form.delete(input.name)
+      }
+    })
+
+    let data = []
+    for (var pair of form.entries()) {
+      data.push([pair[0], pair[1]])
+    }
+    return Object.fromEntries(data)
+  }
+
+  // Ignore inputs when they're about authenticity_token, passwords, captchas, etc
+  // Or when they're marked as ignored
+  isIgnored(input) {
+    const isAuthToken = input.name === "authenticity_token"
+    const isPassword = input.type === "password"
+    const isFile = input.type === "file"
+    const isCaptchaSpinner = input.name === "spinner"
+    const isIgnoredTarget = this.ignoredTargets.map(input => input.name).includes(input.name)
+
+    return isAuthToken || isPassword || isFile || isCaptchaSpinner || isIgnoredTarget
+  }
+
+  getLocalStorageKey() {
+    return window.location
+  }
+}

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -4,7 +4,7 @@
 .container-fluid{data: { controller: "job-offer-management"}}
   .row
     .col-12.px-0
-      = simple_form_for([:admin, @job_offer]) do |f|
+      = simple_form_for([:admin, @job_offer], data: {controller: "form-save", form_save_target: "form", action: "change->form-save#saveFormData submit->form-save#clearFormData"}) do |f|
         = f.error_notification
         = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
         - if @job_offer.errors.any?

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -1,6 +1,6 @@
 - unless user_signed_in?
   = render "devise/shared/france_connect"
-= simple_form_for(@job_application, url: [:send_application, @job_offer], method: :post, data: { turbo: true }) do |f|
+= simple_form_for(@job_application, url: [:send_application, @job_offer], method: :post, data: { turbo: true, controller: "form-save", form_save_target: "form", action: "change->form-save#saveFormData submit->form-save#clearFormData" }) do |f|
   .form-inputs.mt-3
     = f.error_notification
     = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
@@ -57,7 +57,7 @@
         = user_form.input :receive_job_offer_mails
         = user_form.input :terms_of_service, as: :boolean, label: tos_acceptance_text
         = user_form.input :certify_majority, as: :boolean
-    = f.invisible_captcha :subtitle
+    = f.invisible_captcha :subtitle, data: { form_save_target: "ignored" }
   %div
     .rf-input-group.rf-grid-row.rf-grid-row--center.rf-mt-6w
       = button_tag(type: 'submit', class: 'rf-btn rf-btn--lg') do


### PR DESCRIPTION
closes #850

On ajoute la sauvegarde automatique des formulaires suivants : 
- côté admin : la création d'un nouveau job offert
- côté user : la création d'un nouveau job application, c'est à dire le fait de postuler à une offre

Le comportement est donc le suivant :
1. la personne commence à remplir le formulaire
2. elle quitte pour une raison ou une autre (fermeture du navigateur ou de l'onglet, expiration de la session, bouton précédent...)
3. lorsqu'elle revient sur le formulaire, les champs sont remplis avec sa saisie précédente
4. lorsqu'elle soumet le formulaire, la sauvegarde de sa saisie précédente est effacée

Les limites sont les suivantes : 
- les champs de type fichier ne peuvent être sauvegardés, ils ne sont plus accessibles après avoir quitté le formulaire
- les mots de passe sont exclus pour des raisons de sécurité
- les champs dynamiquement ajoutés dans le formulaire n'existe plus lorsque la personne revient sur l'écran, donc ils sont perdus (cela concerne en l'occurrence "Ajouter une langue étrangère" et "Ajouter un souhait géographique").