### PR TITLE
:adhesive_bandage: harmonize job application stats start date

### DIFF
--- a/app/controllers/admin/stats/job_applications_controller.rb
+++ b/app/controllers/admin/stats/job_applications_controller.rb
@@ -65,7 +65,7 @@ class Admin::Stats::JobApplicationsController < Admin::Stats::BaseController
   def date_start
     @date_start ||= begin
       res = Date.parse(permitted_params[:start]) if permitted_params[:start].present?
-      res ||= 30.days.ago.to_date
+      res ||= 1.month.ago.to_date
       res
     end
   end


### PR DESCRIPTION
Default start and end dates should match the cache warming.