### PR TITLE
:children_crossing: individually manage email attachments

### DIFF
--- a/app/javascript/controllers/files_upload_controller.js
+++ b/app/javascript/controllers/files_upload_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "files"]
+
+  connect() {
+    this.files = new DataTransfer()
+    this.settingFiles = false
+  }
+
+  changed(e) {
+    if (this.settingFiles) { return }
+
+    this.storeFiles(e.target.files)
+    this.showFiles(this.files.files)
+  }
+
+  add(e) {
+    this.inputTarget.click()
+    e.preventDefault()
+  }
+
+  remove(e) {
+    this.files.items.remove(e.target.dataset.index)
+    this.showFiles(this.files.files)
+    e.preventDefault()
+  }
+
+  setFilesToUpload() {
+    this.settingFiles = true
+    this.inputTarget.files = this.files.files
+    this.settingFiles = false
+  }
+
+  // private
+
+  storeFiles(files) {
+    for (var i = 0; i < files.length; i++) {
+      this.files.items.add(files[i])
+    }
+  }
+
+  showFiles(files) {
+    this.filesTarget.innerHTML = ""
+
+    for (var i = 0; i < files.length; i++) {
+      let file = files[i]
+
+      let li = document.createElement("li")
+      li.appendChild(document.createTextNode(file.name + " "))
+
+      let a = document.createElement("a")
+      a.href = "#"
+      a.dataset.action = "click->files-upload#remove"
+      a.dataset.index = i
+      a.appendChild(document.createTextNode("Retirer"));
+      li.appendChild(a)
+
+      this.filesTarget.appendChild(li)
+    }
+  }
+}

--- a/app/javascript/controllers/rf_tab_management_controller.js
+++ b/app/javascript/controllers/rf_tab_management_controller.js
@@ -4,6 +4,10 @@ export default class extends Controller {
   static targets = [ 'tablist', 'panel' ]
 
   connect() {
+    this.resize()
+  }
+  
+  resize() {
     var height = this.panelTarget.offsetHeight + this.tablistTarget.offsetHeight
     this.element.style.height = height + 'px'
   }

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -31,7 +31,7 @@ class Email < ApplicationRecord
   def fill_attachments
     return if attachments.blank?
 
-    attachments.map { |a| email_attachments.build(content: a) }
+    attachments.compact_blank.map { |a| email_attachments.build(content: a) }
   end
 
   def mark_as_read!

--- a/app/views/account/emails/_form.html.haml
+++ b/app/views/account/emails/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for([:account, @job_application, email], html: { class: 'rf-box rf-mb-5w rf-pb-5w' }) do |f|
+= simple_form_for([:account, @job_application, email], html: { class: 'rf-box rf-mb-5w rf-pb-5w' }, html: {data: {controller: "files-upload"}}) do |f|
   %strong.d-block.rf-mb-2w= t('.title')
   = f.error_notification
   = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
@@ -6,8 +6,10 @@
   .form-inputs
     = f.input :subject
     = f.input :body
-    = f.file_field :attachments, multiple: true
+    = f.file_field :attachments, multiple: true, data: {action: "change->files-upload#changed change->rf-tab-management#resize", files_upload_target: "input"}, class: "d-none"
+  = link_to t('.add_attachment'), "#", data: {action: "click->files-upload#add"}
+  %ul{data: {files_upload_target: "files"}}
 
   .rf-input-group.rf-grid-row.justify-content-end.rf-mt-3w
-    = button_tag(type: 'submit', class: 'rf-btn') do
+    = button_tag(type: 'submit', class: 'rf-btn', data: {action: "click->files-upload#setFilesToUpload"}) do
       = t('buttons.send')

--- a/app/views/admin/emails/_form.html.haml
+++ b/app/views/admin/emails/_form.html.haml
@@ -9,16 +9,18 @@
       .form-inputs
         = f.input :template, collection: EmailTemplate.all
 
-    = simple_form_for([:admin, @email.job_application, @email], remote: true, defaults: { disabled: is_archived_or_is_deleted }) do |f|
+    = simple_form_for([:admin, @email.job_application, @email], remote: true, defaults: { disabled: is_archived_or_is_deleted }, html: {data: {controller: "files-upload"}}) do |f|
       = f.error_notification
       = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
 
       .form-inputs
         = f.input :subject
         = f.input :body
-        = f.file_field :attachments, multiple: true
+        = f.file_field :attachments, multiple: true, data: {action: "change->files-upload#changed", files_upload_target: "input"}, class: "d-none"
+      = link_to t('.add_attachment'), "#", data: {action: "click->files-upload#add"}
+      %ul{data: {files_upload_target: "files"}}
 
       .form-actions.text-right
-        = button_tag(type: 'submit', class: 'btn btn-primary') do
+        = button_tag(type: 'submit', class: 'btn btn-primary', data: {action: "click->files-upload#setFilesToUpload"}) do
           = t('buttons.send_to_candidate')
           = fa_icon('send', class: 'ml-1')

--- a/app/views/admin/multiple_recipients_emails/new.html.haml
+++ b/app/views/admin/multiple_recipients_emails/new.html.haml
@@ -12,7 +12,7 @@
             .form-inputs
               = f.input :template, required: false, collection: EmailTemplate.all
 
-          = simple_form_for([:admin, @job_offer, @multiple_recipients_email], defaults: { disabled: is_form_disabled? }) do |f|
+          = simple_form_for([:admin, @job_offer, @multiple_recipients_email], defaults: { disabled: is_form_disabled? }, html: {data: {controller: "files-upload"}}) do |f|
             = f.error_notification 
             = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
 
@@ -21,9 +21,11 @@
                 = render partial: "job_application_id", locals: {job_application: job_application}
               = f.input :subject
               = f.input :body, as: :text
-              = f.file_field :attachments, multiple: true
+              = f.file_field :attachments, multiple: true, data: {action: "change->files-upload#changed", files_upload_target: "input"}, class: "d-none"
+            = link_to t('.add_attachment'), "#", data: {action: "click->files-upload#add"}
+            %ul{data: {files_upload_target: "files"}}
 
             .form-actions.text-right
-              = button_tag(type: 'submit', class: 'btn btn-primary', disabled: is_form_disabled?) do
+              = button_tag(type: 'submit', class: 'btn btn-primary', disabled: is_form_disabled?, data: {action: "click->files-upload#setFilesToUpload"}) do
                 = t('buttons.send_to_candidates')
                 = fa_icon('send', class: 'ml-1')

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -460,6 +460,7 @@ fr:
         unsuccess: "Impossible d'envoyer le courriel, veuillez vérifier tous les champs"
       form:
         title: "Envoyer un courriel à ce candidat"
+        add_attachment: "Ajouter une pièce jointe"
       email:
         mark_as_read: "Marquer comme lu"
         mark_as_unread: "Marquer comme non lu"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -213,6 +213,7 @@ fr:
         time_ago: "il y a %{time_ago_in_words}"
       form:
         title: "Envoyer un courriel"
+        add_attachment: "Ajouter une pièce jointe"
       index:
     users:
       link_france_connect:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -471,6 +471,7 @@ fr:
     multiple_recipients_emails:
       new:
         title: "Envoyer un courriel à ces candidat·es"
+        add_attachment: "Ajouter une pièce jointe"
       create:
         success: "Les emails ont été envoyés !"
     messages:


### PR DESCRIPTION
For each email form, allow to:
- add one or multiple files to file input
- remove added files

# Job application (user)

![image](https://user-images.githubusercontent.com/1193334/186395980-09e07920-eb9c-4f35-a1c1-5d6e08ea3322.png)

# Job application (admin)

![image](https://user-images.githubusercontent.com/1193334/186394117-71dc4ccf-cf05-47db-a4c7-e01fe769e66b.png)

# Multiple recipients email

![image](https://user-images.githubusercontent.com/1193334/186393937-8cd9362a-c760-4b8b-a3ee-322dadc19ca4.png)


closes #1029