### PR TITLE
🐛 Fix crashes when contract type is nil

### DIFF
--- a/app/helpers/job_offers_helper.rb
+++ b/app/helpers/job_offers_helper.rb
@@ -35,7 +35,7 @@ module JobOffersHelper
   end
 
   def job_offer_contract_type_display(job_offer)
-    [job_offer.contract_type.name, job_offer.duration_contract].join(" ")
+    [job_offer.contract_type&.name, job_offer.duration_contract].compact.join(" ")
   end
 
   def job_offer_start_display(job_offer)

--- a/app/views/account/job_applications/_job_application.html.haml
+++ b/app/views/account/job_applications/_job_application.html.haml
@@ -9,7 +9,7 @@
     .rf-card__desc
       .d-flex.flex-row
         .d-flex.flex-column
-          %span= [job_offer.contract_type.name, job_offer.duration_contract].join(' ')
+          %span= job_offer_contract_type_display(job_offer)
           %em= job_offer.location
         .d-flex.flex-column.justify-content-center.align-items-center.text-center.ml-auto
           %span= "Étape #{job_application.end_user_state_number}/#{JobApplication.end_user_states_regrouping.size}"

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -19,7 +19,7 @@
           .col-1.text-truncate.font-weight-bold.text-primary.text-dark
             %span{title: job_offer.location}= job_offer.location.split(',').first
           .col-1.text-truncate.font-weight-bold.text-primary.text-dark
-            = job_offer.contract_type.name
+            = job_offer.contract_type&.name
           .col-1.text-truncate.font-weight-bold.text-primary.text-dark.text-center
             - count = job_offer.job_applications_count
             - title = JobOffer.human_attribute_name('job_applications_count', count: count)

--- a/app/views/homepages/_job_offer_headline_card.html.haml
+++ b/app/views/homepages/_job_offer_headline_card.html.haml
@@ -4,7 +4,7 @@
       %h4.rf-card__title
         = link_to job_offer.title, job_offer, class: "rf-card__link"
       %p.rf-card__desc
-        = [job_offer.contract_type.name, job_offer.duration_contract].join(' ')
+        = job_offer_contract_type_display(job_offer)
         %br
         = job_offer.location
       - if job_offer.published_at.present?

--- a/app/views/job_offers/_job_offer.html.haml
+++ b/app/views/job_offers/_job_offer.html.haml
@@ -9,7 +9,7 @@
             %strong.rf-text--lg.rf-mb-1w= job_offer.title
             .d-flex
               .rf-mr-1w
-                = [job_offer.contract_type.name, job_offer.duration_contract].join(' ')
+                = job_offer_contract_type_display(job_offer)
                 %br
                 = job_offer.location
             - if job_offer.published_at.present?

--- a/app/views/job_offers/index.json.jbuilder
+++ b/app/views/job_offers/index.json.jbuilder
@@ -6,7 +6,7 @@ json.array! @job_offers do |job_offer|
     json.libelle job_offer.title
     json.departement job_offer.county_code
     json.ville job_offer.city
-    json.type job_offer.contract_type.name
+    json.type job_offer.contract_type&.name
     json.duree job_offer.contract_duration&.name
     json.niveauEtude job_offer.study_level.official_level
     json.famille job_offer.category.name

--- a/lib/services/exporter/job_offer.rb
+++ b/lib/services/exporter/job_offer.rb
@@ -20,7 +20,7 @@ class Exporter::JobOffer < Exporter::StatJobApplications
       job_offer.title,
       job_offer.employer.name,
       job_offer.sector.name,
-      job_offer.contract_type.name,
+      job_offer.contract_type&.name&.presence || "",
       job_offer.duration_contract,
       job_offer.job_applications_count,
       JobOffer.human_attribute_name("state/#{job_offer.state}"),

--- a/lib/services/exporter/job_offers.rb
+++ b/lib/services/exporter/job_offers.rb
@@ -30,7 +30,7 @@ class Exporter::JobOffers < Exporter::Base
       job_offer.title,
       job_offer.employer.name,
       job_offer.sector.name,
-      job_offer.contract_type.name,
+      job_offer.contract_type&.name&.presence || "",
       job_offer.duration_contract,
       job_offer.job_applications_count,
       JobOffer.human_attribute_name("state/#{job_offer.state}"),

--- a/spec/factories/job_offers.rb
+++ b/spec/factories/job_offers.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
     estimate_annual_salary_gross { "36k€" }
     bne_value { "inconnue" }
     bne_date { 1.day.ago }
+    duration_contract { "duration" }
 
     factory :published_job_offer do
       published_at { 40.days.before }

--- a/spec/helpers/job_offers_helper_spec.rb
+++ b/spec/helpers/job_offers_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe JobOffersHelper, type: :helper do
+  describe ".job_offer_contract_type_display" do
+    subject { job_offer_contract_type_display(job_offer.reload) }
+
+    let!(:job_offer) { create(:job_offer) }
+
+    context "when the job offer has a contract type" do
+      it { is_expected.to eq("CDI duration") }
+    end
+
+    context "when the job offer doesn't have a contract type" do
+      before { ContractType.find_by(name: "CDI").destroy! }
+
+      it { is_expected.to eq("duration") }
+    end
+  end
+end


### PR DESCRIPTION
On a rencontré plusieurs crash en prod : 

https://sentry.incubateur.net/organizations/betagouv/issues/26336/?project=47&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox

https://sentry.incubateur.net/organizations/betagouv/issues/26330/?project=47&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox

https://sentry.incubateur.net/organizations/betagouv/issues/26329/?project=47&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox

Dans tous les cas le problème est le même : le `contract_type` a disparu et ce n'est pas correctement géré par l'application. C'est pourtant une fonctionnalité tout à fait possible, puisqu'on peut supprimer un contract type dans les paramètres de l'admin.

Ici on corrige donc ces différents cas.