### PR TITLE
Track emails sent to administrators

### DIFF
--- a/app/models/admin_email.rb
+++ b/app/models/admin_email.rb
@@ -1,0 +1,19 @@
+class AdminEmail < ApplicationRecord
+  serialize :data
+end
+
+# == Schema Information
+#
+# Table name: admin_emails
+#
+#  id           :uuid             not null, primary key
+#  data         :text
+#  email        :string
+#  service_name :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_admin_emails_on_email  (email)
+#

--- a/app/models/daily_summary.rb
+++ b/app/models/daily_summary.rb
@@ -38,6 +38,7 @@ class DailySummary
     @concerned_administrators.each do |concerned_administrator|
       administrator = administrators.detect { |x| x.id == concerned_administrator.uuid }
       data = concerned_administrator.summary_infos
+      AdminEmail.create!(email: administrator.email, data: data, service_name: service_name)
       NotificationsMailer.daily_summary(administrator, data, service_name).deliver
     end
   end

--- a/db/migrate/20230420144305_create_admin_emails.rb
+++ b/db/migrate/20230420144305_create_admin_emails.rb
@@ -1,0 +1,13 @@
+class CreateAdminEmails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :admin_emails, id: :uuid do |t|
+      t.string :email
+      t.string :service_name
+      t.text :data
+
+      t.timestamps
+    end
+
+    add_index :admin_emails, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_26_140104) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_20_144305) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -44,6 +44,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_26_140104) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "admin_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "email"
+    t.string "service_name"
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_emails_on_email"
   end
 
   create_table "administrators", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Dans le but de débugger #1474, on conserve en BDD la trace des emails envoyés aux administrateur·rices.