### PR TITLE
:sparkles: Secure PDF content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,12 @@ jobs:
       - run: bundle exec rake db:schema:load
       # Fix error with icu4c
       - run: bundle pristine charlock_holmes
+      - run:
+          name: install dependencies to convert pdf to images
+          command: |
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            sudo apt-get update --fix-missing
+            sudo apt-get install -y poppler-utils
       # run tests!
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,11 @@ jobs:
       # Fix error with icu4c
       - run: bundle pristine charlock_holmes
       - run:
-          name: install dependencies to convert pdf to images
+          name: install dependencies to convert pdf to images and images to pdf
           command: |
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             sudo apt-get update --fix-missing
-            sudo apt-get install -y poppler-utils
+            sudo apt-get install -y poppler-utils img2pdf
       # run tests!
       - run:
           name: run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -y yarn
 RUN apt-get install -y imagemagick
 RUN apt-get install -y locales
 RUN apt-get install -y postgresql-client
+RUN apt-get install -y poppler-utils
 
 ENV NODE_VERSION 12.16.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get install -y imagemagick
 RUN apt-get install -y locales
 RUN apt-get install -y postgresql-client
 RUN apt-get install -y poppler-utils
+RUN apt-get install -y img2pdf
 
 ENV NODE_VERSION 12.16.1
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ou
 - Yarn
 - Redis
 - ImageMagick
+- poppler-utils
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ou
 - Redis
 - ImageMagick
 - poppler-utils
+- img2pdf
 
 ### Installation
 

--- a/app/jobs/secure_content_job.rb
+++ b/app/jobs/secure_content_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SecureContentJob < ApplicationJob
+  queue_as :default
+
+  def perform(id:)
+    JobApplicationFile.find_by(id: id)&.secure_content!
+  end
+end

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -2,6 +2,7 @@
 
 # Container for real file mandatory to fullfill a job application
 class JobApplicationFile < ApplicationRecord
+  include Securable
   attr_accessor :job_application_file_existing_id, :do_not_provide_immediately
 
   belongs_to :job_application
@@ -49,6 +50,7 @@ end
 #  content_file_name                :string
 #  encrypted_file_transfer_in_error :boolean          default(FALSE)
 #  is_validated                     :integer          default(0)
+#  secured_content_file_name        :string
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  job_application_file_type_id     :uuid

--- a/app/models/job_application_file/securable.rb
+++ b/app/models/job_application_file/securable.rb
@@ -1,0 +1,56 @@
+module JobApplicationFile::Securable
+  extend ActiveSupport::Concern
+
+  included do
+    mount_uploader :secured_content, DocumentUploader, mount_on: :secured_content_file_name
+
+    after_commit -> { SecureContentJob.perform_later(id: id) }, unless: -> { secured? }
+  end
+
+  def secured?
+    secured_content.present?
+  end
+
+  def secure_content!
+    return if secured? || content.blank?
+
+    image_file_names = convert_to_images(download(original_file_path, content.read))
+
+    convert_to_pdf(image_file_names, secured_file_path)
+
+    update(secured_content: File.open(secured_file_path))
+
+    delete_files(image_file_names + [original_file_path, secured_file_path])
+  end
+
+  private
+
+  def original_file_path
+    content_file_name
+  end
+
+  def secured_file_path
+    "secured_#{original_file_path}"
+  end
+
+  def download(file_path, content)
+    FileUtils.mkdir_p(File.dirname(file_path))
+    file = File.open(file_path, "w+")
+    file.write(content.force_encoding("UTF-8"))
+    file.close
+    file
+  end
+
+  def convert_to_images(pdf_file)
+    system("pdftoppm", pdf_file.path, "page", "-png")
+    Dir.entries(".").select { _1.start_with?("page-") }.sort
+  end
+
+  def convert_to_pdf(image_file_names, file_path)
+    system("img2pdf", *image_file_names, "-o", file_path)
+  end
+
+  def delete_files(file_names)
+    # file_names.select { File.exist?(_1) }.each { File.delete(_1) }
+  end
+end

--- a/db/migrate/20230501155549_add_secured_content_file_name_to_job_application_files.rb
+++ b/db/migrate/20230501155549_add_secured_content_file_name_to_job_application_files.rb
@@ -1,0 +1,5 @@
+class AddSecuredContentFileNameToJobApplicationFiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :job_application_files, :secured_content_file_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_28_082102) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_01_193755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -334,6 +334,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_082102) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "encrypted_file_transfer_in_error", default: false
+    t.string "secured_content_file_name"
     t.index ["job_application_file_type_id"], name: "index_job_application_files_on_job_application_file_type_id"
     t.index ["job_application_id"], name: "index_job_application_files_on_job_application_id"
   end

--- a/lib/tasks/migrate_data/secure_contents.rake
+++ b/lib/tasks/migrate_data/secure_contents.rake
@@ -1,0 +1,14 @@
+namespace :migrate_data do
+  task secure_contents: :environment do
+    job_application_files = JobApplicationFile.where(secured_content_file_name: nil)
+
+    Rails.logger.info("Migration start for #{job_application_files.count} job application files")
+
+    job_application_files.find_each do |job_application_file|
+      Rails.logger.info("Securing job application file #{job_application_file.id}")
+      job_application_file.secure_content!
+    end
+
+    Rails.logger.info("All done!")
+  end
+end

--- a/spec/factories/job_application_files.rb
+++ b/spec/factories/job_application_files.rb
@@ -10,6 +10,15 @@ FactoryBot.define do
     end
     job_application_file_type
     job_application
+
+    trait :secured do
+      secured_content do
+        Rack::Test::UploadedFile.new(
+          Rails.root.join("spec/fixtures/files/document.pdf"),
+          "application/pdf"
+        )
+      end
+    end
   end
 end
 
@@ -21,6 +30,7 @@ end
 #  content_file_name                :string
 #  encrypted_file_transfer_in_error :boolean          default(FALSE)
 #  is_validated                     :integer          default(0)
+#  secured_content_file_name        :string
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  job_application_file_type_id     :uuid

--- a/spec/jobs/secure_content_job_spec.rb
+++ b/spec/jobs/secure_content_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SecureContentJob, type: :job do
+  subject(:perform) { described_class.new.perform(id: job_application_file.id) }
+
+  context "when the job application file is not found" do
+    let(:job_application_file) { instance_double(JobApplicationFile, id: -1) }
+
+    it "does nothing" do
+      expect_any_instance_of(JobApplicationFile).not_to receive(:secure_content!)
+      perform
+    end
+  end
+
+  context "when the job application file is found" do
+    let(:job_application_file) { create(:job_application_file) }
+
+    it "secures the job application file's content" do
+      expect_any_instance_of(JobApplicationFile).to receive(:secure_content!)
+      perform
+    end
+  end
+end

--- a/spec/models/job_application_file/securable_spec.rb
+++ b/spec/models/job_application_file/securable_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe JobApplicationFile::Securable, type: :model do
+  describe "#secured?" do
+    subject(:secured?) { job_application_file.secured? }
+
+    context "when the job application file is secured" do
+      let(:job_application_file) { build(:job_application_file, :secured) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the job application file is not secured" do
+      let(:job_application_file) { build(:job_application_file) }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#secure_content!" do
+    subject(:secure_content!) { job_application_file.secure_content! }
+
+    context "when the job application file is already secured" do
+      let!(:job_application_file) { create(:job_application_file, :secured) }
+
+      it { expect { secure_content! }.not_to change { job_application_file.reload.secured? } }
+    end
+
+    context "when the job application file is not secured" do
+      let!(:job_application_file) { create(:job_application_file) }
+
+      context "when the job application file content is blank" do
+        before { allow_any_instance_of(JobApplicationFile).to receive(:content).and_return(nil) }
+
+        it { expect { secure_content! }.not_to change { job_application_file.reload.secured? } }
+      end
+
+      context "when the job application file content is present" do
+        it { expect { secure_content! }.to change { job_application_file.reload.secured_content.present? }.to(true) }
+
+        it { expect { secure_content! }.to change { job_application_file.reload.secured? }.to(true) }
+      end
+    end
+  end
+
+  describe "After commit" do
+    subject(:commit) { job_application_file.save }
+
+    context "when the job application file is secured" do
+      let(:job_application_file) { build(:job_application_file, :secured) }
+
+      it { expect { commit }.not_to have_enqueued_job { SecureContentJob } }
+    end
+
+    context "when the job application file is not secured" do
+      let!(:job_application_file) { build(:job_application_file) }
+
+      it { expect { commit }.to have_enqueued_job { SecureContentJob }.with(job_application_file.id) }
+    end
+  end
+end


### PR DESCRIPTION
# Description

Afin d'éviter les injections de scripts dans les documents PDF (voir #1406), on les sécurise de la manière suivante : 
- on transforme le document en images, grâce à `pdftoppm` (de poppler-utils)
- on transforme les images en document PDF, grâce à `img2pdf`

On ajoute donc la dépendance poppler-utils et la dépendance `img2pdf`.

Partout dans l'application, on utilise cette version sécurisée du document PDF. On conserve néanmoins l'original, pour future référence.

# Production :warning: 

Jouer la migration suivante : 

`rails migrate_data:secure_contents`