### PR TITLE
:heavy_plus_sign: Add pdf and img dependencies

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
+https://github.com/Scalingo/apt-buildpack.git
 https://github.com/Scalingo/nodejs-buildpack.git
 https://github.com/Scalingo/ruby-buildpack.git

--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,1 @@
+poppler-utils

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,2 @@
 poppler-utils
+img2pdf


### PR DESCRIPTION
On vérifie en amont de https://github.com/betagouv/civilsdeladefense/pull/1498 qu'il est possible d'exécuter pdftoppm (poppler-utils) et img2pdf en environnement de production.