### PR TITLE
:bug: Fix ul / ol style on job offer content

### DIFF
--- a/app/javascript/css/_job_offer_content.scss
+++ b/app/javascript/css/_job_offer_content.scss
@@ -1,0 +1,17 @@
+.job-offer-content {
+  ul, ol { 
+    display: block;
+    list-style: disc outside none;
+    margin: 1em 0;
+    padding: 0 0 0 40px;
+  }
+
+  ol { 
+    list-style-type: decimal;
+    counter-reset: revert;
+  }
+
+  li { 
+    display: list-item;
+  }
+}

--- a/app/javascript/css/application.scss
+++ b/app/javascript/css/application.scss
@@ -2,6 +2,7 @@
 @import "stepper";
 @import "alert";
 @import "france-connect";
+@import "job_offer_content";
 
 // Design System overflow fix
 @media (min-width: 48em) {

--- a/app/views/job_offers/_job_offer_content.html.haml
+++ b/app/views/job_offers/_job_offer_content.html.haml
@@ -1,9 +1,10 @@
-- display_apply_button = @job_offer.published?
-- cache job_offer do
-  - fields = %i(organization_description description required_profile recruitment_process)
-  - fields.each_with_index do |field, index|
-    %h2.rf-h3.rf-mt-0= t('.'+field.to_s)
-    = sanitize(job_offer.send(field))
-- if display_apply_button && !(controller.action_name == 'apply')
-  .rf-grid-row.rf-grid-row--center.rf-mt-4w
-    = link_to t('.apply'), apply_job_offers_path(id: @job_offer.slug), class: 'rf-btn rf-btn--lg', rel: 'noindex nofollow'
+.job-offer-content
+  - display_apply_button = @job_offer.published?
+  - cache job_offer do
+    - fields = %i(organization_description description required_profile recruitment_process)
+    - fields.each_with_index do |field, index|
+      %h2.rf-h3.rf-mt-0= t('.'+field.to_s)
+      = sanitize(job_offer.send(field))
+  - if display_apply_button && !(controller.action_name == 'apply')
+    .rf-grid-row.rf-grid-row--center.rf-mt-4w
+      = link_to t('.apply'), apply_job_offers_path(id: @job_offer.slug), class: 'rf-btn rf-btn--lg', rel: 'noindex nofollow'


### PR DESCRIPTION
Comme décrit dans #1489, le style des listes à puces ne s'affiche pas, sur les instances de staging / production uniquement (c'est ok en local). C'est vraisemblablement une conséquence de la version du DSFR qui est incluse dans le projet.

Ici, on reconstruit les styles de ul / ol pour les job offers.

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/3c3aff6a-f4b7-44b7-934c-16bae41e70cc)

closes #1489 
