### PR TITLE
💬 Update wording for suspended user

### DIFF
--- a/app/models/concerns/suspendable.rb
+++ b/app/models/concerns/suspendable.rb
@@ -32,6 +32,10 @@ module Suspendable
     super && !suspended?
   end
 
+  def inactive_message
+    suspended? ? :suspended : super
+  end
+
   private
 
   def prevent_deletion_when_suspended

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -45,6 +45,7 @@ fr:
     failure:
       already_authenticated: Vous êtes déjà connecté(e).
       inactive: Votre compte n’est pas encore activé.
+      suspended: Connexion impossible, veuillez réessayer ultérieurement.
       invalid: "%{authentication_keys} ou mot de passe incorrect."
       last_attempt: Il vous reste une chance avant que votre compte soit bloqué.
       locked: Votre compte est verrouillé.

--- a/spec/models/concerns/suspendable_spec.rb
+++ b/spec/models/concerns/suspendable_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Suspendable, type: :model do
+  describe "#suspended" do
+    subject { user.suspended? }
+
+    let(:user) { build(:user, suspended_at: suspended_at) }
+
+    context "when the user is suspended" do
+      let(:suspended_at) { Time.zone.now }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the user is not suspended" do
+      let(:suspended_at) { nil }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#inactive_message" do
+    subject { user.inactive_message }
+
+    let(:user) { create(:confirmed_user, suspended_at: suspended_at) }
+
+    context "when the user is suspended" do
+      let(:suspended_at) { Time.zone.now }
+
+      it { is_expected.to eq(:suspended) }
+    end
+
+    context "when the user is not suspended" do
+      let(:suspended_at) { nil }
+
+      it { is_expected.to eq(:inactive) }
+    end
+  end
+end


### PR DESCRIPTION
On met à jour le message qui s'affiche lorsqu'un compte est suspendu.

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/75629a09-5ee7-466b-b5be-335bd4fbaf11)


closes #1507