### PR TITLE
:bug: Fix undefined body error

### DIFF
--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -19,7 +19,7 @@ module Securable
   end
 
   def secure_content!
-    return if secured? || content.blank? || content.content_type != "application/pdf"
+    return if secured? || content.blank? || !pdf?
 
     secured = convert_images_to_pdf(convert_original_content_to_images)
     update!(secured_content: secured)
@@ -71,5 +71,11 @@ module Securable
 
   def delete_files(filenames)
     filenames.select { File.exist?(_1) }.each { File.delete(_1) }
+  end
+
+  def pdf?
+    content.content_type == "application/pdf"
+  rescue # sometimes getting the content_type throws an error, because the file is not there
+    false
   end
 end


### PR DESCRIPTION
Sometimes getting the content_type of a file throws an error, because the file is not there or not readable from Outscale. It may occur for old files / unstable content.

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/92eacc0c-dc40-40fd-9b2c-21a084057f44)

That's because:

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/f0e36df1-bbb7-488b-ac64-0de678e9f8d2)
