### PR TITLE
🐛 Fix original content download

### DIFF
--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -31,11 +31,11 @@ module Securable
   private
 
   def convert_original_content_to_images(density)
-    original_filename = content.filename
+    original_filename = content.filename.parameterize
     original_file = download(original_filename, content.read)
     image_filenames = convert_to_images(original_file, density)
     original_file.close
-    File.delete(original_filename)
+    File.delete(original_filename) if File.exist?(original_filename)
     image_filenames
   end
 


### PR DESCRIPTION
When the original content filename contains special chars, downloading the file may fails.

We fix it by parameterizing the filename.