### PR TITLE
🚸 Deliver secured content only when env var is set

### DIFF
--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -1,7 +1,10 @@
 module Securable
   extend ActiveSupport::Concern
 
+  DELIVER_SECURED_CONTENT = ENV["DELIVER_SECURED_CONTENT"]
+
   included do
+
     mount_uploader :secured_content, DocumentUploader, mount_on: :secured_content_file_name
 
     after_commit -> { SecureContentJob.set(wait: 1.minute).perform_later(id: id) },
@@ -10,7 +13,7 @@ module Securable
   end
 
   def document_content
-    return secured_content if secured_content.present?
+    return secured_content if DELIVER_SECURED_CONTENT && secured_content.present?
     return content if content.present?
   end
 

--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -4,7 +4,6 @@ module Securable
   DELIVER_SECURED_CONTENT = ENV["DELIVER_SECURED_CONTENT"]
 
   included do
-
     mount_uploader :secured_content, DocumentUploader, mount_on: :secured_content_file_name
 
     after_commit -> { SecureContentJob.set(wait: 1.minute).perform_later(id: id) },

--- a/spec/models/concerns/securable_spec.rb
+++ b/spec/models/concerns/securable_spec.rb
@@ -9,7 +9,17 @@ RSpec.describe Securable, type: :model do
     context "when the secured_content exists" do
       let(:securable) { build(:job_application_file, :secured) }
 
-      it { is_expected.to eq(securable.secured_content) }
+      context "when DELIVER_SECURED_CONTENT is set" do
+        before { stub_const "Securable::DELIVER_SECURED_CONTENT", "1" }
+
+        it { is_expected.to eq(securable.secured_content) }
+      end
+
+      context "when DELIVER_SECURED_CONTENT is unset" do
+        before { stub_const "Securable::DELIVER_SECURED_CONTENT", nil }
+
+        it { is_expected.to eq(securable.content) }
+      end
     end
 
     context "when the secured content doesn't exist" do


### PR DESCRIPTION
Define the `DELIVER_SECURED_CONTENT` in order to deliver secured content.
Unset it to deliver regular content.

(content is the content of PDF file, see #1502)