### PR TITLE
Improve secured PDF file quality

### DIFF
--- a/app/jobs/secure_content_job.rb
+++ b/app/jobs/secure_content_job.rb
@@ -5,8 +5,6 @@ class SecureContentJob < ApplicationJob
 
   def perform(id:)
     securable(id)&.secure_content!
-  rescue # if image magick fails because the image quality is to high, try again with lower density
-    securable(id)&.secure_content!(density: 150)
   end
 
   private

--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -20,9 +20,9 @@ module Securable
     secured_content.present?
   end
 
-  def secure_content!(density: 300)
+  def secure_content!
     return if secured? || content.blank? || !pdf?
-    return if (images = convert_original_content_to_images(density)).empty?
+    return if (images = convert_original_content_to_images).empty?
 
     secured_filename = content.filename
     PdfUtils.convert_images_to_pdf(images, secured_filename)
@@ -33,10 +33,10 @@ module Securable
 
   private
 
-  def convert_original_content_to_images(density)
+  def convert_original_content_to_images
     original_filename = content.filename.parameterize
     original_file = download(original_filename, content.read)
-    image_filenames = PdfUtils.convert_pdf_file_to_images(original_file, density)
+    image_filenames = PdfUtils.convert_pdf_file_to_images(original_file)
     original_file.close
     PdfUtils.delete_files([original_filename])
     image_filenames
@@ -49,7 +49,6 @@ module Securable
     file.close
     file
   end
-
 
   def pdf?
     content.content_type == "application/pdf"

--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -6,7 +6,7 @@ module Securable
   included do
     mount_uploader :secured_content, DocumentUploader, mount_on: :secured_content_file_name
 
-    after_commit -> { SecureContentJob.set(wait: 1.minute).perform_later(id: id) },
+    after_commit -> { SecureContentJob.set(wait: 15.seconds).perform_later(id: id) },
       unless: -> { secured? },
       if: -> { content.present? && pdf? }
   end

--- a/lib/pdf_utils.rb
+++ b/lib/pdf_utils.rb
@@ -1,0 +1,35 @@
+module PdfUtils
+  class << self
+    def convert_pdf_file_to_images(pdf_file, density = 150)
+      image = MiniMagick::Image.open(pdf_file.path)
+      prefix = SecureRandom.base36
+      image.pages.each_with_index { |page, index| PdfUtils.convert_pdf_page_to_image(prefix, page.path, index, density) }
+      Dir.entries(".").select { _1.start_with?(prefix) }.sort
+    rescue # ImageMagick failure: sometimes the pdf can't be opened
+      []
+    end
+
+    def convert_pdf_page_to_image(image_filename_prefix, page_path, index, density)
+      MiniMagick::Tool::Convert.new do |convert|
+        convert << "-quality" << "100"
+        convert << "-density" << density.to_s
+        convert << "-alpha" << "remove"
+        convert << "-background" << "white"
+        convert << "-flatten"
+        convert << page_path
+        convert << "#{image_filename_prefix}-#{index.to_s.rjust(5, "0")}.png"
+      end
+    end
+
+    def convert_images_to_pdf(image_filenames, filename)
+      MiniMagick::Tool::Convert.new do |convert|
+        image_filenames.each { convert << _1 }
+        convert << filename
+      end
+    end
+
+    def delete_files(filenames)
+      filenames.select { File.exist?(_1) }.each { File.delete(_1) }
+    end
+  end
+end

--- a/lib/tasks/migrate_data/secure_contents.rake
+++ b/lib/tasks/migrate_data/secure_contents.rake
@@ -7,6 +7,16 @@ namespace :migrate_data do
     secure_contents(EmailAttachment)
   end
 
+  desc "Convert all PDF files (in the current directory) to images and back to PDF to secure them"
+  task convert: :environment do
+    Dir.entries(".").select { _1.end_with?(".pdf") }.map { File.open(_1) }.each do |pdf_file|
+      puts "Converting #{pdf_file.path}"
+      images = convert_to_images(pdf_file, 150) # TODO SEB: density?
+      convert_images_to_pdf("converted_#{pdf_file.path}", images)
+      delete_files(images)
+    end
+  end
+
   private
 
   def secure_contents(model)
@@ -21,5 +31,36 @@ namespace :migrate_data do
     end
 
     Rails.logger.info("All done!")
+  end
+
+  def convert_to_images(pdf_file, density)
+    id = pdf_file.path.parameterize
+    image = MiniMagick::Image.open(pdf_file.path)
+    image.pages.each_with_index { |page, index| convert_page_with_mini_magick(id, page.path, index, density) }
+    Dir.entries(".").select { _1.start_with?("secured-image-#{id}-") }.sort
+  end
+
+  # TODO SEB: move to a util module
+  def convert_page_with_mini_magick(id, page_path, index, density)
+    MiniMagick::Tool::Convert.new do |convert|
+      convert << "-quality" << "100"
+      convert << "-density" << density.to_s
+      convert << "-alpha" << "remove" # TODO SEB: remove alpha
+      convert << "-background" << "white" # TODO SEB: background
+      convert << "-flatten" # TODO SEB: flatten
+      convert << page_path
+      convert << "secured-image-#{id}-#{index.to_s.rjust(5, "0")}.png" # TODO SEB: PNG to keep size low
+    end
+  end
+
+  def convert_images_to_pdf(secured_filename, image_filenames)
+    MiniMagick::Tool::Convert.new do |convert|
+      image_filenames.each { convert << _1 }
+      convert << secured_filename
+    end
+  end
+
+  def delete_files(filenames)
+    filenames.select { File.exist?(_1) }.each { File.delete(_1) }
   end
 end

--- a/lib/tasks/migrate_data/secure_contents.rake
+++ b/lib/tasks/migrate_data/secure_contents.rake
@@ -9,11 +9,11 @@ namespace :migrate_data do
 
   desc "Convert all PDF files (in the current directory) to images and back to PDF to secure them"
   task convert: :environment do
-    Dir.entries(".").select { _1.end_with?(".pdf") }.map { File.open(_1) }.each do |pdf_file|
-      puts "Converting #{pdf_file.path}"
-      images = convert_to_images(pdf_file, 150) # TODO SEB: density?
-      convert_images_to_pdf("converted_#{pdf_file.path}", images)
-      delete_files(images)
+    Dir.entries(".").select { _1.end_with?(".pdf") }.map { File.open(_1) }.each do |pdf|
+      puts "Converting #{pdf.path}"
+      images = PdfUtils.convert_pdf_file_to_images(pdf)
+      PdfUtils.convert_images_to_pdf(images, "converted_#{pdf.path}")
+      PdfUtils.delete_files(images)
     end
   end
 
@@ -31,36 +31,5 @@ namespace :migrate_data do
     end
 
     Rails.logger.info("All done!")
-  end
-
-  def convert_to_images(pdf_file, density)
-    id = pdf_file.path.parameterize
-    image = MiniMagick::Image.open(pdf_file.path)
-    image.pages.each_with_index { |page, index| convert_page_with_mini_magick(id, page.path, index, density) }
-    Dir.entries(".").select { _1.start_with?("secured-image-#{id}-") }.sort
-  end
-
-  # TODO SEB: move to a util module
-  def convert_page_with_mini_magick(id, page_path, index, density)
-    MiniMagick::Tool::Convert.new do |convert|
-      convert << "-quality" << "100"
-      convert << "-density" << density.to_s
-      convert << "-alpha" << "remove" # TODO SEB: remove alpha
-      convert << "-background" << "white" # TODO SEB: background
-      convert << "-flatten" # TODO SEB: flatten
-      convert << page_path
-      convert << "secured-image-#{id}-#{index.to_s.rjust(5, "0")}.png" # TODO SEB: PNG to keep size low
-    end
-  end
-
-  def convert_images_to_pdf(secured_filename, image_filenames)
-    MiniMagick::Tool::Convert.new do |convert|
-      image_filenames.each { convert << _1 }
-      convert << secured_filename
-    end
-  end
-
-  def delete_files(filenames)
-    filenames.select { File.exist?(_1) }.each { File.delete(_1) }
   end
 end

--- a/lib/tasks/migrate_data/secure_contents.rake
+++ b/lib/tasks/migrate_data/secure_contents.rake
@@ -26,8 +26,6 @@ namespace :migrate_data do
     entries.find_each do |securable|
       Rails.logger.info("Securing #{securable.id}")
       securable.secure_content!
-    rescue # if image magick fails because the image quality is to high, try again with lower density
-      securable.secure_content!(density: 150)
     end
 
     Rails.logger.info("All done!")


### PR DESCRIPTION
Pour résoudre les problèmes relevés dans les documents PDF sécurisés, on apporte plusieurs modification dans le processus de sécurisation.

Cette PR règle :
- le problème d'absence de visibilité du contenu (PDF qui sortaient en noir)
- le problème de la taille des fichiers (qui passaient de quelques centaines de Ko à plusieurs Mo)
- le problème de qualité / lisibilité variable à cause de la densité (elle est désormais à 150 et la qualité des fichiers semble bonne)

closes #1541 